### PR TITLE
Do not ignore custom DevToolsService configuration

### DIFF
--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/services/impl/ChromeServiceImpl.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/services/impl/ChromeServiceImpl.java
@@ -175,10 +175,6 @@ public class ChromeServiceImpl implements ChromeService {
       WebSocketService webSocketService =
           webSocketServiceFactory.createWebSocketService(webSocketDebuggerUrl);
 
-      // DevTools service configuration
-      ChromeDevToolsServiceConfiguration serviceConfiguration =
-          new ChromeDevToolsServiceConfiguration();
-
       // Create invocation handler
       CommandInvocationHandler commandInvocationHandler = new CommandInvocationHandler();
 
@@ -190,7 +186,7 @@ public class ChromeServiceImpl implements ChromeService {
           ProxyUtils.createProxyFromAbstract(
               ChromeDevToolsServiceImpl.class,
               new Class[] {WebSocketService.class, ChromeDevToolsServiceConfiguration.class},
-              new Object[] {webSocketService, serviceConfiguration},
+              new Object[] {webSocketService, chromeDevToolsServiceConfiguration},
               (unused, method, args) ->
                   commandsCache.computeIfAbsent(
                       method,


### PR DESCRIPTION
When calling `ChromeDevToolsService#createDevToolsService(ChromeTab tab, ChromeDevToolsServiceConfiguration chromeDevToolsServiceConfiguration)`, the `chromeDevToolsServiceConfiguration` is ignored and a new configuration instance is created instead.

This PR uses the passed configuration and closes #9.