### PR TITLE
Ensure exception gets logged correctly

### DIFF
--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/services/impl/ChromeDevToolsServiceImpl.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/services/impl/ChromeDevToolsServiceImpl.java
@@ -294,7 +294,7 @@ public abstract class ChromeDevToolsServiceImpl
 
                   listener.getHandler().onEvent(event);
                 } catch (Exception e) {
-                  LOGGER.error("Error while processing event {}", name, e);
+                  LOGGER.error("Error while processing event " + name, e);
                 }
               }
             });


### PR DESCRIPTION
Just a minor fix to make sure the exception is passed as second argument to the logger, so that it gets logged correctly.