### PR TITLE
Update protocol to latest

### DIFF
--- a/browser_protocol.json
+++ b/browser_protocol.json
@@ -740,6 +740,9 @@
         {
             "domain": "ApplicationCache",
             "experimental": true,
+            "dependencies": [
+                "Page"
+            ],
             "types": [
                 {
                     "id": "ApplicationCacheResource",
@@ -916,6 +919,290 @@
             "dependencies": [
                 "Network"
             ],
+            "types": [
+                {
+                    "id": "AffectedCookie",
+                    "description": "Information about a cookie that is affected by an inspector issue.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "name",
+                            "description": "The following three properties uniquely identify a cookie",
+                            "type": "string"
+                        },
+                        {
+                            "name": "path",
+                            "type": "string"
+                        },
+                        {
+                            "name": "domain",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "AffectedRequest",
+                    "description": "Information about a request that is affected by an inspector issue.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "requestId",
+                            "description": "The unique request id.",
+                            "$ref": "Network.RequestId"
+                        },
+                        {
+                            "name": "url",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "AffectedFrame",
+                    "description": "Information about the frame affected by an inspector issue.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "frameId",
+                            "$ref": "Page.FrameId"
+                        }
+                    ]
+                },
+                {
+                    "id": "SameSiteCookieExclusionReason",
+                    "type": "string",
+                    "enum": [
+                        "ExcludeSameSiteUnspecifiedTreatedAsLax",
+                        "ExcludeSameSiteNoneInsecure"
+                    ]
+                },
+                {
+                    "id": "SameSiteCookieWarningReason",
+                    "type": "string",
+                    "enum": [
+                        "WarnSameSiteUnspecifiedCrossSiteContext",
+                        "WarnSameSiteNoneInsecure",
+                        "WarnSameSiteUnspecifiedLaxAllowUnsafe",
+                        "WarnSameSiteStrictLaxDowngradeStrict",
+                        "WarnSameSiteStrictCrossDowngradeStrict",
+                        "WarnSameSiteStrictCrossDowngradeLax",
+                        "WarnSameSiteLaxCrossDowngradeStrict",
+                        "WarnSameSiteLaxCrossDowngradeLax"
+                    ]
+                },
+                {
+                    "id": "SameSiteCookieOperation",
+                    "type": "string",
+                    "enum": [
+                        "SetCookie",
+                        "ReadCookie"
+                    ]
+                },
+                {
+                    "id": "SameSiteCookieIssueDetails",
+                    "description": "This information is currently necessary, as the front-end has a difficult\ntime finding a specific cookie. With this, we can convey specific error\ninformation without the cookie.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "cookie",
+                            "$ref": "AffectedCookie"
+                        },
+                        {
+                            "name": "cookieWarningReasons",
+                            "type": "array",
+                            "items": {
+                                "$ref": "SameSiteCookieWarningReason"
+                            }
+                        },
+                        {
+                            "name": "cookieExclusionReasons",
+                            "type": "array",
+                            "items": {
+                                "$ref": "SameSiteCookieExclusionReason"
+                            }
+                        },
+                        {
+                            "name": "operation",
+                            "description": "Optionally identifies the site-for-cookies and the cookie url, which\nmay be used by the front-end as additional context.",
+                            "$ref": "SameSiteCookieOperation"
+                        },
+                        {
+                            "name": "siteForCookies",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "cookieUrl",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "request",
+                            "optional": true,
+                            "$ref": "AffectedRequest"
+                        }
+                    ]
+                },
+                {
+                    "id": "MixedContentResolutionStatus",
+                    "type": "string",
+                    "enum": [
+                        "MixedContentBlocked",
+                        "MixedContentAutomaticallyUpgraded",
+                        "MixedContentWarning"
+                    ]
+                },
+                {
+                    "id": "MixedContentResourceType",
+                    "type": "string",
+                    "enum": [
+                        "Audio",
+                        "Beacon",
+                        "CSPReport",
+                        "Download",
+                        "EventSource",
+                        "Favicon",
+                        "Font",
+                        "Form",
+                        "Frame",
+                        "Image",
+                        "Import",
+                        "Manifest",
+                        "Ping",
+                        "PluginData",
+                        "PluginResource",
+                        "Prefetch",
+                        "Resource",
+                        "Script",
+                        "ServiceWorker",
+                        "SharedWorker",
+                        "Stylesheet",
+                        "Track",
+                        "Video",
+                        "Worker",
+                        "XMLHttpRequest",
+                        "XSLT"
+                    ]
+                },
+                {
+                    "id": "MixedContentIssueDetails",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "resourceType",
+                            "description": "The type of resource causing the mixed content issue (css, js, iframe,\nform,...). Marked as optional because it is mapped to from\nblink::mojom::RequestContextType, which will be replaced\nby network::mojom::RequestDestination",
+                            "optional": true,
+                            "$ref": "MixedContentResourceType"
+                        },
+                        {
+                            "name": "resolutionStatus",
+                            "description": "The way the mixed content issue is being resolved.",
+                            "$ref": "MixedContentResolutionStatus"
+                        },
+                        {
+                            "name": "insecureURL",
+                            "description": "The unsafe http url causing the mixed content issue.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "mainResourceURL",
+                            "description": "The url responsible for the call to an unsafe url.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "request",
+                            "description": "The mixed content request.\nDoes not always exist (e.g. for unsafe form submission urls).",
+                            "optional": true,
+                            "$ref": "AffectedRequest"
+                        },
+                        {
+                            "name": "frame",
+                            "description": "Optional because not every mixed content issue is necessarily linked to a frame.",
+                            "optional": true,
+                            "$ref": "AffectedFrame"
+                        }
+                    ]
+                },
+                {
+                    "id": "BlockedByResponseReason",
+                    "description": "Enum indicating the reason a response has been blocked. These reasons are\nrefinements of the net error BLOCKED_BY_RESPONSE.",
+                    "type": "string",
+                    "enum": [
+                        "CoepFrameResourceNeedsCoepHeader",
+                        "CoopSandboxedIFrameCannotNavigateToCoopPage",
+                        "CorpNotSameOrigin",
+                        "CorpNotSameOriginAfterDefaultedToSameOriginByCoep",
+                        "CorpNotSameSite"
+                    ]
+                },
+                {
+                    "id": "BlockedByResponseIssueDetails",
+                    "description": "Details for a request that has been blocked with the BLOCKED_BY_RESPONSE\ncode. Currently only used for COEP/COOP, but may be extended to include\nsome CSP errors in the future.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "request",
+                            "$ref": "AffectedRequest"
+                        },
+                        {
+                            "name": "frame",
+                            "optional": true,
+                            "$ref": "AffectedFrame"
+                        },
+                        {
+                            "name": "reason",
+                            "$ref": "BlockedByResponseReason"
+                        }
+                    ]
+                },
+                {
+                    "id": "InspectorIssueCode",
+                    "description": "A unique identifier for the type of issue. Each type may use one of the\noptional fields in InspectorIssueDetails to convey more specific\ninformation about the kind of issue.",
+                    "type": "string",
+                    "enum": [
+                        "SameSiteCookieIssue",
+                        "MixedContentIssue",
+                        "BlockedByResponseIssue"
+                    ]
+                },
+                {
+                    "id": "InspectorIssueDetails",
+                    "description": "This struct holds a list of optional fields with additional information\nspecific to the kind of issue. When adding a new issue code, please also\nadd a new optional field to this type.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "sameSiteCookieIssueDetails",
+                            "optional": true,
+                            "$ref": "SameSiteCookieIssueDetails"
+                        },
+                        {
+                            "name": "mixedContentIssueDetails",
+                            "optional": true,
+                            "$ref": "MixedContentIssueDetails"
+                        },
+                        {
+                            "name": "blockedByResponseIssueDetails",
+                            "optional": true,
+                            "$ref": "BlockedByResponseIssueDetails"
+                        }
+                    ]
+                },
+                {
+                    "id": "InspectorIssue",
+                    "description": "An inspector issue reported from the back-end.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "code",
+                            "$ref": "InspectorIssueCode"
+                        },
+                        {
+                            "name": "details",
+                            "$ref": "InspectorIssueDetails"
+                        }
+                    ]
+                }
+            ],
             "commands": [
                 {
                     "name": "getEncodedResponse",
@@ -965,6 +1252,25 @@
                             "name": "encodedSize",
                             "description": "Size after re-encoding.",
                             "type": "integer"
+                        }
+                    ]
+                },
+                {
+                    "name": "disable",
+                    "description": "Disables issues domain, prevents further issues from being reported to the client."
+                },
+                {
+                    "name": "enable",
+                    "description": "Enables issues domain, sends the issues collected so far to the client by means of the\n`issueAdded` event."
+                }
+            ],
+            "events": [
+                {
+                    "name": "issueAdded",
+                    "parameters": [
+                        {
+                            "name": "issue",
+                            "$ref": "InspectorIssue"
                         }
                     ]
                 }
@@ -1126,6 +1432,11 @@
             "description": "The Browser domain defines methods and events for browser managing.",
             "types": [
                 {
+                    "id": "BrowserContextID",
+                    "experimental": true,
+                    "type": "string"
+                },
+                {
                     "id": "WindowID",
                     "experimental": true,
                     "type": "integer"
@@ -1189,13 +1500,14 @@
                         "audioCapture",
                         "backgroundSync",
                         "backgroundFetch",
-                        "clipboardRead",
-                        "clipboardWrite",
+                        "clipboardReadWrite",
+                        "clipboardSanitizedWrite",
                         "durableStorage",
                         "flash",
                         "geolocation",
                         "midi",
                         "midiSysex",
+                        "nfc",
                         "notifications",
                         "paymentHandler",
                         "periodicBackgroundSync",
@@ -1245,6 +1557,12 @@
                             "description": "For \"wake-lock\" permission, must specify type as either \"screen\" or \"system\".",
                             "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "allowWithoutSanitization",
+                            "description": "For \"clipboard\" permission, may specify allowWithoutSanitization.",
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ]
                 },
@@ -1310,11 +1628,6 @@
                     "experimental": true,
                     "parameters": [
                         {
-                            "name": "origin",
-                            "description": "Origin the permission applies to.",
-                            "type": "string"
-                        },
-                        {
                             "name": "permission",
                             "description": "Descriptor of permission to override.",
                             "$ref": "PermissionDescriptor"
@@ -1325,10 +1638,16 @@
                             "$ref": "PermissionSetting"
                         },
                         {
+                            "name": "origin",
+                            "description": "Origin the permission applies to, all origins if not specified.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
                             "name": "browserContextId",
                             "description": "Context to override. When omitted, default browser context is used.",
                             "optional": true,
-                            "$ref": "Target.TargetID"
+                            "$ref": "BrowserContextID"
                         }
                     ]
                 },
@@ -1338,10 +1657,6 @@
                     "experimental": true,
                     "parameters": [
                         {
-                            "name": "origin",
-                            "type": "string"
-                        },
-                        {
                             "name": "permissions",
                             "type": "array",
                             "items": {
@@ -1349,10 +1664,16 @@
                             }
                         },
                         {
+                            "name": "origin",
+                            "description": "Origin the permission applies to, all origins if not specified.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
                             "name": "browserContextId",
                             "description": "BrowserContext to override permissions. When omitted, default browser context is used.",
                             "optional": true,
-                            "$ref": "Target.BrowserContextID"
+                            "$ref": "BrowserContextID"
                         }
                     ]
                 },
@@ -1365,7 +1686,37 @@
                             "name": "browserContextId",
                             "description": "BrowserContext to reset permissions. When omitted, default browser context is used.",
                             "optional": true,
-                            "$ref": "Target.BrowserContextID"
+                            "$ref": "BrowserContextID"
+                        }
+                    ]
+                },
+                {
+                    "name": "setDownloadBehavior",
+                    "description": "Set the behavior when downloading a file.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "behavior",
+                            "description": "Whether to allow all or deny all download requests, or use default Chrome behavior if\navailable (otherwise deny). |allowAndName| allows download and names files according to\ntheir dowmload guids.",
+                            "type": "string",
+                            "enum": [
+                                "deny",
+                                "allow",
+                                "allowAndName",
+                                "default"
+                            ]
+                        },
+                        {
+                            "name": "browserContextId",
+                            "description": "BrowserContext to set download behavior. When omitted, default browser context is used.",
+                            "optional": true,
+                            "$ref": "BrowserContextID"
+                        },
+                        {
+                            "name": "downloadPath",
+                            "description": "The default path to save downloaded files to. This is requred if behavior is set to 'allow'\nor 'allowAndName'.",
+                            "optional": true,
+                            "type": "string"
                         }
                     ]
                 },
@@ -1569,7 +1920,8 @@
             "description": "This domain exposes CSS read/write operations. All CSS objects (stylesheets, rules, and styles)\nhave an associated `id` used in subsequent operations on the related object. Each object type has\na specific `id` structure, and those are not interchangeable between objects of different kinds.\nCSS objects can be loaded using the `get*ForNode()` calls (which accept a DOM node id). A client\ncan also keep track of stylesheets via the `styleSheetAdded`/`styleSheetRemoved` events and\nsubsequently load the required stylesheet contents using the `getStyleSheet[Text]()` methods.",
             "experimental": true,
             "dependencies": [
-                "DOM"
+                "DOM",
+                "Page"
             ],
             "types": [
                 {
@@ -1757,6 +2109,16 @@
                         {
                             "name": "length",
                             "description": "Size of the content (in characters).",
+                            "type": "number"
+                        },
+                        {
+                            "name": "endLine",
+                            "description": "Line offset of the end of the stylesheet within the resource (zero based).",
+                            "type": "number"
+                        },
+                        {
+                            "name": "endColumn",
+                            "description": "Column offset of the end of the stylesheet within the resource (zero based).",
                             "type": "number"
                         }
                     ]
@@ -2675,6 +3037,11 @@
                             "items": {
                                 "$ref": "RuleUsage"
                             }
+                        },
+                        {
+                            "name": "timestamp",
+                            "description": "Monotonically increasing time, in seconds.",
+                            "type": "number"
                         }
                     ]
                 }
@@ -2946,11 +3313,13 @@
                         {
                             "name": "skipCount",
                             "description": "Number of records to skip.",
+                            "optional": true,
                             "type": "integer"
                         },
                         {
                             "name": "pageSize",
                             "description": "Number of records to fetch.",
+                            "optional": true,
                             "type": "integer"
                         },
                         {
@@ -3124,6 +3493,7 @@
                         "first-letter",
                         "before",
                         "after",
+                        "marker",
                         "backdrop",
                         "selection",
                         "first-line-inherited",
@@ -3563,6 +3933,37 @@
                     ]
                 },
                 {
+                    "name": "scrollIntoViewIfNeeded",
+                    "description": "Scrolls the specified rect of the given node into view if not already visible.\nNote: exactly one between nodeId, backendNodeId and objectId should be passed\nto identify the node.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "nodeId",
+                            "description": "Identifier of the node.",
+                            "optional": true,
+                            "$ref": "NodeId"
+                        },
+                        {
+                            "name": "backendNodeId",
+                            "description": "Identifier of the backend node.",
+                            "optional": true,
+                            "$ref": "BackendNodeId"
+                        },
+                        {
+                            "name": "objectId",
+                            "description": "JavaScript object id of the node wrapper.",
+                            "optional": true,
+                            "$ref": "Runtime.RemoteObjectId"
+                        },
+                        {
+                            "name": "rect",
+                            "description": "The rect to be scrolled into view, relative to the node's border box, in CSS pixels.\nWhen omitted, center of the node will be used, similar to Element.scrollIntoView.",
+                            "optional": true,
+                            "$ref": "Rect"
+                        }
+                    ]
+                },
+                {
                     "name": "disable",
                     "description": "Disables DOM agent for the given page."
                 },
@@ -3749,7 +4150,6 @@
                 {
                     "name": "getNodeForLocation",
                     "description": "Returns node id at given location. Depending on whether DOM domain is enabled, nodeId is\neither returned or not.",
-                    "experimental": true,
                     "parameters": [
                         {
                             "name": "x",
@@ -3766,6 +4166,12 @@
                             "description": "False to skip to the nearest non-UA shadow root ancestor (default: false).",
                             "optional": true,
                             "type": "boolean"
+                        },
+                        {
+                            "name": "ignorePointerEventsNone",
+                            "description": "Whether to ignore pointer-events: none on elements and hit test them.",
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ],
                     "returns": [
@@ -3773,6 +4179,11 @@
                             "name": "backendNodeId",
                             "description": "Resulting node.",
                             "$ref": "BackendNodeId"
+                        },
+                        {
+                            "name": "frameId",
+                            "description": "Frame this node belongs to.",
+                            "$ref": "Page.FrameId"
                         },
                         {
                             "name": "nodeId",
@@ -5215,6 +5626,11 @@
                             "$ref": "StringIndex"
                         },
                         {
+                            "name": "title",
+                            "description": "Document title.",
+                            "$ref": "StringIndex"
+                        },
+                        {
                             "name": "baseURL",
                             "description": "Base URL that `Document` or `FrameOwner` node uses for URL completion.",
                             "$ref": "StringIndex"
@@ -5268,6 +5684,18 @@
                         {
                             "name": "scrollOffsetY",
                             "description": "Vertical scroll offset.",
+                            "optional": true,
+                            "type": "number"
+                        },
+                        {
+                            "name": "contentWidth",
+                            "description": "Document content width.",
+                            "optional": true,
+                            "type": "number"
+                        },
+                        {
+                            "name": "contentHeight",
+                            "description": "Document content height.",
                             "optional": true,
                             "type": "number"
                         }
@@ -5977,6 +6405,20 @@
                     ]
                 },
                 {
+                    "id": "MediaFeature",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "name",
+                            "type": "string"
+                        },
+                        {
+                            "name": "value",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
                     "id": "VirtualTimePolicy",
                     "description": "advance: If the scheduler runs out of immediate work, the virtual time base may fast forward to\nallow the next delayed task (if any) to run; pause: The virtual time base may not advance;\npauseIfNetworkFetchesPending: The virtual time base may not advance if there are any pending\nresource fetches.",
                     "experimental": true,
@@ -5985,6 +6427,61 @@
                         "advance",
                         "pause",
                         "pauseIfNetworkFetchesPending"
+                    ]
+                },
+                {
+                    "id": "UserAgentBrandVersion",
+                    "description": "Used to specify User Agent Cient Hints to emulate. See https://wicg.github.io/ua-client-hints",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "brand",
+                            "type": "string"
+                        },
+                        {
+                            "name": "version",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "UserAgentMetadata",
+                    "description": "Used to specify User Agent Cient Hints to emulate. See https://wicg.github.io/ua-client-hints",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "brands",
+                            "type": "array",
+                            "items": {
+                                "$ref": "UserAgentBrandVersion"
+                            }
+                        },
+                        {
+                            "name": "fullVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "platform",
+                            "type": "string"
+                        },
+                        {
+                            "name": "platformVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "architecture",
+                            "type": "string"
+                        },
+                        {
+                            "name": "model",
+                            "type": "string"
+                        },
+                        {
+                            "name": "mobile",
+                            "type": "boolean"
+                        }
                     ]
                 }
             ],
@@ -6175,12 +6672,42 @@
                 },
                 {
                     "name": "setEmulatedMedia",
-                    "description": "Emulates the given media for CSS media queries.",
+                    "description": "Emulates the given media type or media feature for CSS media queries.",
                     "parameters": [
                         {
                             "name": "media",
                             "description": "Media type to emulate. Empty string disables the override.",
+                            "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "features",
+                            "description": "Media features to emulate.",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "MediaFeature"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "setEmulatedVisionDeficiency",
+                    "description": "Emulates the given vision deficiency.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "type",
+                            "description": "Vision deficiency to emulate.",
+                            "type": "string",
+                            "enum": [
+                                "none",
+                                "achromatopsia",
+                                "blurredVision",
+                                "deuteranopia",
+                                "protanopia",
+                                "tritanopia"
+                            ]
                         }
                     ]
                 },
@@ -6304,6 +6831,19 @@
                     ]
                 },
                 {
+                    "name": "setLocaleOverride",
+                    "description": "Overrides default host system locale with the specified one.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "locale",
+                            "description": "ICU style C locale (e.g. \"en_US\"). If not specified or empty, disables the override and\nrestores default host system locale.",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
                     "name": "setTimezoneOverride",
                     "description": "Overrides default host system timezone with the specified one.",
                     "experimental": true,
@@ -6353,6 +6893,13 @@
                             "description": "The platform navigator.platform should return.",
                             "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "userAgentMetadata",
+                            "description": "To be sent in Sec-CH-UA-* headers and returned in navigator.userAgentData",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "UserAgentMetadata"
                         }
                     ]
                 }
@@ -6454,7 +7001,8 @@
             "events": [
                 {
                     "name": "needsBeginFramesChanged",
-                    "description": "Issued when the target starts or stops needing BeginFrames.",
+                    "description": "Issued when the target starts or stops needing BeginFrames.\nDeprecated. Issue beginFrame unconditionally instead and use result from\nbeginFrame to detect whether the frames were suppressed.",
+                    "deprecated": true,
                     "parameters": [
                         {
                             "name": "needsBeginFrames",
@@ -7031,6 +7579,18 @@
                     ]
                 },
                 {
+                    "id": "MouseButton",
+                    "type": "string",
+                    "enum": [
+                        "none",
+                        "left",
+                        "middle",
+                        "right",
+                        "back",
+                        "forward"
+                    ]
+                },
+                {
                     "id": "TimeSinceEpoch",
                     "description": "UTC time in seconds, counted from January 1, 1970.",
                     "type": "number"
@@ -7185,15 +7745,7 @@
                             "name": "button",
                             "description": "Mouse button (default: \"none\").",
                             "optional": true,
-                            "type": "string",
-                            "enum": [
-                                "none",
-                                "left",
-                                "middle",
-                                "right",
-                                "back",
-                                "forward"
-                            ]
+                            "$ref": "MouseButton"
                         },
                         {
                             "name": "buttons",
@@ -7296,14 +7848,8 @@
                         },
                         {
                             "name": "button",
-                            "description": "Mouse button.",
-                            "type": "string",
-                            "enum": [
-                                "none",
-                                "left",
-                                "middle",
-                                "right"
-                            ]
+                            "description": "Mouse button. Only \"none\", \"left\", \"right\" are supported.",
+                            "$ref": "MouseButton"
                         },
                         {
                             "name": "timestamp",
@@ -7747,6 +8293,15 @@
                         {
                             "name": "compositingReasons",
                             "description": "A list of strings specifying reasons for the given layer to become composited.",
+                            "deprecated": true,
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "name": "compositingReasonIds",
+                            "description": "A list of strings specifying reason IDs for the given layer to become composited.",
                             "type": "array",
                             "items": {
                                 "type": "string"
@@ -8402,8 +8957,18 @@
                     "enum": [
                         "Strict",
                         "Lax",
-                        "Extended",
                         "None"
+                    ]
+                },
+                {
+                    "id": "CookiePriority",
+                    "description": "Represents the cookie's 'Priority' status:\nhttps://tools.ietf.org/html/draft-west-cookie-priority-00",
+                    "experimental": true,
+                    "type": "string",
+                    "enum": [
+                        "Low",
+                        "Medium",
+                        "High"
                     ]
                 },
                 {
@@ -8465,6 +9030,18 @@
                         {
                             "name": "workerReady",
                             "description": "Finished Starting ServiceWorker.",
+                            "experimental": true,
+                            "type": "number"
+                        },
+                        {
+                            "name": "workerFetchStart",
+                            "description": "Started fetch event.",
+                            "experimental": true,
+                            "type": "number"
+                        },
+                        {
+                            "name": "workerRespondWithSettled",
+                            "description": "Settled fetch event respondWith promise.",
                             "experimental": true,
                             "type": "number"
                         },
@@ -8730,7 +9307,12 @@
                         "inspector",
                         "subresource-filter",
                         "content-type",
-                        "collapsed-by-client"
+                        "collapsed-by-client",
+                        "coep-frame-resource-needs-coep-header",
+                        "coop-sandboxed-iframe-cannot-navigate-to-coop-page",
+                        "corp-not-same-origin",
+                        "corp-not-same-origin-after-defaulted-to-same-origin-by-coep",
+                        "corp-not-same-site"
                     ]
                 },
                 {
@@ -9045,6 +9627,12 @@
                             "description": "Cookie SameSite type.",
                             "optional": true,
                             "$ref": "CookieSameSite"
+                        },
+                        {
+                            "name": "priority",
+                            "description": "Cookie Priority",
+                            "experimental": true,
+                            "$ref": "CookiePriority"
                         }
                     ]
                 },
@@ -9057,7 +9645,6 @@
                         "SecureOnly",
                         "SameSiteStrict",
                         "SameSiteLax",
-                        "SameSiteExtended",
                         "SameSiteUnspecifiedTreatedAsLax",
                         "SameSiteNoneInsecure",
                         "UserPreferences",
@@ -9080,7 +9667,6 @@
                         "DomainMismatch",
                         "SameSiteStrict",
                         "SameSiteLax",
-                        "SameSiteExtended",
                         "SameSiteUnspecifiedTreatedAsLax",
                         "SameSiteNoneInsecure",
                         "UserPreferences",
@@ -9094,9 +9680,12 @@
                     "type": "object",
                     "properties": [
                         {
-                            "name": "blockedReason",
-                            "description": "The reason this cookie was blocked.",
-                            "$ref": "SetCookieBlockedReason"
+                            "name": "blockedReasons",
+                            "description": "The reason(s) this cookie was blocked.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "SetCookieBlockedReason"
+                            }
                         },
                         {
                             "name": "cookieLine",
@@ -9118,9 +9707,12 @@
                     "type": "object",
                     "properties": [
                         {
-                            "name": "blockedReason",
-                            "description": "The reason the cookie was blocked.",
-                            "$ref": "CookieBlockedReason"
+                            "name": "blockedReasons",
+                            "description": "The reason(s) the cookie was blocked.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "CookieBlockedReason"
+                            }
                         },
                         {
                             "name": "cookie",
@@ -9185,6 +9777,13 @@
                             "description": "Cookie expiration date, session cookie if not set",
                             "optional": true,
                             "$ref": "TimeSinceEpoch"
+                        },
+                        {
+                            "name": "priority",
+                            "description": "Cookie Priority.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "CookiePriority"
                         }
                     ]
                 },
@@ -9932,6 +10531,13 @@
                             "description": "Cookie expiration date, session cookie if not set",
                             "optional": true,
                             "$ref": "TimeSinceEpoch"
+                        },
+                        {
+                            "name": "priority",
+                            "description": "Cookie Priority type.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "CookiePriority"
                         }
                     ],
                     "returns": [
@@ -10021,6 +10627,13 @@
                             "description": "The platform navigator.platform should return.",
                             "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "userAgentMetadata",
+                            "description": "To be sent in Sec-CH-UA-* headers and returned in navigator.userAgentData",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "Emulation.UserAgentMetadata"
                         }
                     ]
                 }
@@ -10533,8 +11146,8 @@
                             "$ref": "RequestId"
                         },
                         {
-                            "name": "blockedCookies",
-                            "description": "A list of cookies which will not be sent with this request along with corresponding reasons\nfor blocking.",
+                            "name": "associatedCookies",
+                            "description": "A list of cookies potentially associated to the requested URL. This includes both cookies sent with\nthe request and the ones not sent; the latter are distinguished by having blockedReason field set.",
                             "type": "array",
                             "items": {
                                 "$ref": "BlockedCookieWithReason"
@@ -10590,6 +11203,67 @@
                 "Runtime"
             ],
             "types": [
+                {
+                    "id": "GridHighlightConfig",
+                    "description": "Configuration data for the highlighting of Grid elements.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "showGridExtensionLines",
+                            "description": "Whether the extension lines from grid cells to the rulers should be shown (default: false).",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "gridBorderColor",
+                            "description": "The grid container border highlight color (default: transparent).",
+                            "optional": true,
+                            "$ref": "DOM.RGBA"
+                        },
+                        {
+                            "name": "cellBorderColor",
+                            "description": "The cell border color (default: transparent).",
+                            "optional": true,
+                            "$ref": "DOM.RGBA"
+                        },
+                        {
+                            "name": "gridBorderDash",
+                            "description": "Whether the grid border is dashed (default: false).",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "cellBorderDash",
+                            "description": "Whether the cell border is dashed (default: false).",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "rowGapColor",
+                            "description": "The row gap highlight fill color (default: transparent).",
+                            "optional": true,
+                            "$ref": "DOM.RGBA"
+                        },
+                        {
+                            "name": "rowHatchColor",
+                            "description": "The row gap hatching fill color (default: transparent).",
+                            "optional": true,
+                            "$ref": "DOM.RGBA"
+                        },
+                        {
+                            "name": "columnGapColor",
+                            "description": "The column gap highlight fill color (default: transparent).",
+                            "optional": true,
+                            "$ref": "DOM.RGBA"
+                        },
+                        {
+                            "name": "columnHatchColor",
+                            "description": "The column gap hatching fill color (default: transparent).",
+                            "optional": true,
+                            "$ref": "DOM.RGBA"
+                        }
+                    ]
+                },
                 {
                     "id": "HighlightConfig",
                     "description": "Configuration data for the highlighting of page elements.",
@@ -10666,6 +11340,51 @@
                             "description": "The grid layout color (default: transparent).",
                             "optional": true,
                             "$ref": "DOM.RGBA"
+                        },
+                        {
+                            "name": "colorFormat",
+                            "description": "The color format used to format color styles (default: hex).",
+                            "optional": true,
+                            "$ref": "ColorFormat"
+                        },
+                        {
+                            "name": "gridHighlightConfig",
+                            "description": "The grid layout highlight configuration (default: all transparent).",
+                            "optional": true,
+                            "$ref": "GridHighlightConfig"
+                        }
+                    ]
+                },
+                {
+                    "id": "ColorFormat",
+                    "type": "string",
+                    "enum": [
+                        "rgb",
+                        "hsl",
+                        "hex"
+                    ]
+                },
+                {
+                    "id": "HingeConfig",
+                    "description": "Configuration for dual screen hinge",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "rect",
+                            "description": "A rectangle represent hinge",
+                            "$ref": "DOM.Rect"
+                        },
+                        {
+                            "name": "contentColor",
+                            "description": "The content box highlight fill color (default: a dark color).",
+                            "optional": true,
+                            "$ref": "DOM.RGBA"
+                        },
+                        {
+                            "name": "outlineColor",
+                            "description": "The content box highlight outline color (default: transparent).",
+                            "optional": true,
+                            "$ref": "DOM.RGBA"
                         }
                     ]
                 },
@@ -10710,6 +11429,12 @@
                             "description": "Whether to include style info.",
                             "optional": true,
                             "type": "boolean"
+                        },
+                        {
+                            "name": "colorFormat",
+                            "description": "The color format to get config with (default: hex)",
+                            "optional": true,
+                            "$ref": "ColorFormat"
                         }
                     ],
                     "returns": [
@@ -10956,6 +11681,18 @@
                             "name": "show",
                             "description": "Whether to paint size or not.",
                             "type": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "name": "setShowHinge",
+                    "description": "Add a dual screen device hinge",
+                    "parameters": [
+                        {
+                            "name": "hingeConfig",
+                            "description": "hinge data, null means hideHinge",
+                            "optional": true,
+                            "$ref": "HingeConfig"
                         }
                     ]
                 }
@@ -11311,6 +12048,19 @@
                     ]
                 },
                 {
+                    "id": "AppManifestParsedProperties",
+                    "description": "Parsed app manifest properties.",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "scope",
+                            "description": "Computed scope value",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
                     "id": "LayoutViewport",
                     "description": "Layout viewport position and dimensions.",
                     "type": "object",
@@ -11498,7 +12248,73 @@
                         "scriptInitiated",
                         "metaTagRefresh",
                         "pageBlockInterstitial",
-                        "reload"
+                        "reload",
+                        "anchorClick"
+                    ]
+                },
+                {
+                    "id": "ClientNavigationDisposition",
+                    "experimental": true,
+                    "type": "string",
+                    "enum": [
+                        "currentTab",
+                        "newTab",
+                        "newWindow",
+                        "download"
+                    ]
+                },
+                {
+                    "id": "InstallabilityErrorArgument",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "name",
+                            "description": "Argument name (e.g. name:'minimum-icon-size-in-pixels').",
+                            "type": "string"
+                        },
+                        {
+                            "name": "value",
+                            "description": "Argument value (e.g. value:'64').",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "InstallabilityError",
+                    "description": "The installability error",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "errorId",
+                            "description": "The error id (e.g. 'manifest-missing-suitable-icon').",
+                            "type": "string"
+                        },
+                        {
+                            "name": "errorArguments",
+                            "description": "The list of error arguments (e.g. {name:'minimum-icon-size-in-pixels', value:'64'}).",
+                            "type": "array",
+                            "items": {
+                                "$ref": "InstallabilityErrorArgument"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "ReferrerPolicy",
+                    "description": "The referring-policy used for the navigation.",
+                    "experimental": true,
+                    "type": "string",
+                    "enum": [
+                        "noReferrer",
+                        "noReferrerWhenDowngrade",
+                        "origin",
+                        "originWhenCrossOrigin",
+                        "sameOrigin",
+                        "strictOrigin",
+                        "strictOriginWhenCrossOrigin",
+                        "unsafeUrl"
                     ]
                 }
             ],
@@ -11712,6 +12528,13 @@
                             "description": "Manifest content.",
                             "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "parsed",
+                            "description": "Parsed manifest properties",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "AppManifestParsedProperties"
                         }
                     ]
                 },
@@ -11720,11 +12543,22 @@
                     "experimental": true,
                     "returns": [
                         {
-                            "name": "errors",
+                            "name": "installabilityErrors",
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "$ref": "InstallabilityError"
                             }
+                        }
+                    ]
+                },
+                {
+                    "name": "getManifestIcons",
+                    "experimental": true,
+                    "returns": [
+                        {
+                            "name": "primaryIcon",
+                            "optional": true,
+                            "type": "string"
                         }
                     ]
                 },
@@ -11884,6 +12718,13 @@
                             "description": "Frame id to navigate, if not specified navigates the top frame.",
                             "optional": true,
                             "$ref": "FrameId"
+                        },
+                        {
+                            "name": "referrerPolicy",
+                            "description": "Referrer-policy used for the navigation.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "ReferrerPolicy"
                         }
                     ],
                     "returns": [
@@ -12303,6 +13144,7 @@
                     "name": "setDownloadBehavior",
                     "description": "Set the behavior when downloading a file.",
                     "experimental": true,
+                    "deprecated": true,
                     "parameters": [
                         {
                             "name": "behavior",
@@ -12517,37 +13359,12 @@
                 },
                 {
                     "name": "setInterceptFileChooserDialog",
-                    "description": "Intercept file chooser requests and transfer control to protocol clients.\nWhen file chooser interception is enabled, native file chooser dialog is not shown.\nInstead, a protocol event `Page.fileChooserOpened` is emitted.\nFile chooser can be handled with `page.handleFileChooser` command.",
+                    "description": "Intercept file chooser requests and transfer control to protocol clients.\nWhen file chooser interception is enabled, native file chooser dialog is not shown.\nInstead, a protocol event `Page.fileChooserOpened` is emitted.",
                     "experimental": true,
                     "parameters": [
                         {
                             "name": "enabled",
                             "type": "boolean"
-                        }
-                    ]
-                },
-                {
-                    "name": "handleFileChooser",
-                    "description": "Accepts or cancels an intercepted file chooser dialog.",
-                    "experimental": true,
-                    "parameters": [
-                        {
-                            "name": "action",
-                            "type": "string",
-                            "enum": [
-                                "accept",
-                                "cancel",
-                                "fallback"
-                            ]
-                        },
-                        {
-                            "name": "files",
-                            "description": "Array of absolute file paths to set, only respected with `accept` action.",
-                            "optional": true,
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
                         }
                     ]
                 }
@@ -12567,7 +13384,20 @@
                     "description": "Emitted only when `page.interceptFileChooser` is enabled.",
                     "parameters": [
                         {
+                            "name": "frameId",
+                            "description": "Id of the frame containing input node.",
+                            "experimental": true,
+                            "$ref": "FrameId"
+                        },
+                        {
+                            "name": "backendNodeId",
+                            "description": "Input node id.",
+                            "experimental": true,
+                            "$ref": "DOM.BackendNodeId"
+                        },
+                        {
                             "name": "mode",
+                            "description": "Input mode.",
                             "type": "string",
                             "enum": [
                                 "selectSingle",
@@ -12655,6 +13485,11 @@
                             "name": "url",
                             "description": "The destination URL for the requested navigation.",
                             "type": "string"
+                        },
+                        {
+                            "name": "disposition",
+                            "description": "The disposition for the navigation.",
+                            "$ref": "ClientNavigationDisposition"
                         }
                     ]
                 },
@@ -12676,16 +13511,7 @@
                         {
                             "name": "reason",
                             "description": "The reason for the navigation.",
-                            "type": "string",
-                            "enum": [
-                                "formSubmissionGet",
-                                "formSubmissionPost",
-                                "httpHeaderRefresh",
-                                "scriptInitiated",
-                                "metaTagRefresh",
-                                "pageBlockInterstitial",
-                                "reload"
-                            ]
+                            "$ref": "ClientNavigationReason"
                         },
                         {
                             "name": "url",
@@ -12729,9 +13555,51 @@
                             "$ref": "FrameId"
                         },
                         {
+                            "name": "guid",
+                            "description": "Global unique identifier of the download.",
+                            "type": "string"
+                        },
+                        {
                             "name": "url",
                             "description": "URL of the resource being downloaded.",
                             "type": "string"
+                        },
+                        {
+                            "name": "suggestedFilename",
+                            "description": "Suggested file name of the resource (the actual name of the file saved on disk may differ).",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "name": "downloadProgress",
+                    "description": "Fired when download makes progress. Last call has |done| == true.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "guid",
+                            "description": "Global unique identifier of the download.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "totalBytes",
+                            "description": "Total expected bytes to download.",
+                            "type": "number"
+                        },
+                        {
+                            "name": "receivedBytes",
+                            "description": "Total bytes received.",
+                            "type": "number"
+                        },
+                        {
+                            "name": "state",
+                            "description": "Download status.",
+                            "type": "string",
+                            "enum": [
+                                "inProgress",
+                                "completed",
+                                "canceled"
+                            ]
                         }
                     ]
                 },
@@ -12950,12 +13818,25 @@
                 },
                 {
                     "name": "enable",
-                    "description": "Enable collecting and reporting metrics."
+                    "description": "Enable collecting and reporting metrics.",
+                    "parameters": [
+                        {
+                            "name": "timeDomain",
+                            "description": "Time domain to use for collecting and reporting duration metrics.",
+                            "optional": true,
+                            "type": "string",
+                            "enum": [
+                                "timeTicks",
+                                "threadTicks"
+                            ]
+                        }
+                    ]
                 },
                 {
                     "name": "setTimeDomain",
                     "description": "Sets time domain to use for collecting and reporting duration metrics.\nNote that this must be called before enabling metrics collection. Calling\nthis method while metrics collection is enabled returns an error.",
                     "experimental": true,
+                    "deprecated": true,
                     "parameters": [
                         {
                             "name": "timeDomain",
@@ -13033,7 +13914,172 @@
                         "neutral",
                         "insecure",
                         "secure",
-                        "info"
+                        "info",
+                        "insecure-broken"
+                    ]
+                },
+                {
+                    "id": "CertificateSecurityState",
+                    "description": "Details about the security state of the page certificate.",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "protocol",
+                            "description": "Protocol name (e.g. \"TLS 1.2\" or \"QUIC\").",
+                            "type": "string"
+                        },
+                        {
+                            "name": "keyExchange",
+                            "description": "Key Exchange used by the connection, or the empty string if not applicable.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "keyExchangeGroup",
+                            "description": "(EC)DH group used by the connection, if applicable.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "cipher",
+                            "description": "Cipher name.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "mac",
+                            "description": "TLS MAC. Note that AEAD ciphers do not have separate MACs.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "certificate",
+                            "description": "Page certificate.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "name": "subjectName",
+                            "description": "Certificate subject name.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "issuer",
+                            "description": "Name of the issuing CA.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "validFrom",
+                            "description": "Certificate valid from date.",
+                            "$ref": "Network.TimeSinceEpoch"
+                        },
+                        {
+                            "name": "validTo",
+                            "description": "Certificate valid to (expiration) date",
+                            "$ref": "Network.TimeSinceEpoch"
+                        },
+                        {
+                            "name": "certificateNetworkError",
+                            "description": "The highest priority network error code, if the certificate has an error.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "certificateHasWeakSignature",
+                            "description": "True if the certificate uses a weak signature aglorithm.",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "certificateHasSha1Signature",
+                            "description": "True if the certificate has a SHA1 signature in the chain.",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "modernSSL",
+                            "description": "True if modern SSL",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "obsoleteSslProtocol",
+                            "description": "True if the connection is using an obsolete SSL protocol.",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "obsoleteSslKeyExchange",
+                            "description": "True if the connection is using an obsolete SSL key exchange.",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "obsoleteSslCipher",
+                            "description": "True if the connection is using an obsolete SSL cipher.",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "obsoleteSslSignature",
+                            "description": "True if the connection is using an obsolete SSL signature.",
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "id": "SafetyTipStatus",
+                    "experimental": true,
+                    "type": "string",
+                    "enum": [
+                        "badReputation",
+                        "lookalike"
+                    ]
+                },
+                {
+                    "id": "SafetyTipInfo",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "safetyTipStatus",
+                            "description": "Describes whether the page triggers any safety tips or reputation warnings. Default is unknown.",
+                            "$ref": "SafetyTipStatus"
+                        },
+                        {
+                            "name": "safeUrl",
+                            "description": "The URL the safety tip suggested (\"Did you mean?\"). Only filled in for lookalike matches.",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "VisibleSecurityState",
+                    "description": "Security state information about the page.",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "securityState",
+                            "description": "The security level of the page.",
+                            "$ref": "SecurityState"
+                        },
+                        {
+                            "name": "certificateSecurityState",
+                            "description": "Security state details about the page certificate.",
+                            "optional": true,
+                            "$ref": "CertificateSecurityState"
+                        },
+                        {
+                            "name": "safetyTipInfo",
+                            "description": "The type of Safety Tip triggered on the page. Note that this field will be set even if the Safety Tip UI was not actually shown.",
+                            "optional": true,
+                            "$ref": "SafetyTipInfo"
+                        },
+                        {
+                            "name": "securityStateIssueIds",
+                            "description": "Array of security state issues ids.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
                     ]
                 },
                 {
@@ -13213,6 +14259,18 @@
                     ]
                 },
                 {
+                    "name": "visibleSecurityStateChanged",
+                    "description": "The security state of the page changed.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "visibleSecurityState",
+                            "description": "Security state information about the page.",
+                            "$ref": "VisibleSecurityState"
+                        }
+                    ]
+                },
+                {
                     "name": "securityStateChanged",
                     "description": "The security state of the page changed.",
                     "parameters": [
@@ -13254,6 +14312,9 @@
         {
             "domain": "ServiceWorker",
             "experimental": true,
+            "dependencies": [
+                "Target"
+            ],
             "types": [
                 {
                     "id": "RegistrationID",
@@ -13552,6 +14613,10 @@
         {
             "domain": "Storage",
             "experimental": true,
+            "dependencies": [
+                "Browser",
+                "Network"
+            ],
             "types": [
                 {
                     "id": "StorageType",
@@ -13603,6 +14668,60 @@
                             "name": "storageTypes",
                             "description": "Comma separated list of StorageType to clear.",
                             "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "name": "getCookies",
+                    "description": "Returns all browser cookies.",
+                    "parameters": [
+                        {
+                            "name": "browserContextId",
+                            "description": "Browser context to use when called on the browser endpoint.",
+                            "optional": true,
+                            "$ref": "Browser.BrowserContextID"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "cookies",
+                            "description": "Array of cookie objects.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "Network.Cookie"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "setCookies",
+                    "description": "Sets given cookies.",
+                    "parameters": [
+                        {
+                            "name": "cookies",
+                            "description": "Cookies to be set.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "Network.CookieParam"
+                            }
+                        },
+                        {
+                            "name": "browserContextId",
+                            "description": "Browser context to use when called on the browser endpoint.",
+                            "optional": true,
+                            "$ref": "Browser.BrowserContextID"
+                        }
+                    ]
+                },
+                {
+                    "name": "clearCookies",
+                    "description": "Clears cookies.",
+                    "parameters": [
+                        {
+                            "name": "browserContextId",
+                            "description": "Browser context to use when called on the browser endpoint.",
+                            "optional": true,
+                            "$ref": "Browser.BrowserContextID"
                         }
                     ]
                 },
@@ -13762,6 +14881,18 @@
                         {
                             "name": "deviceId",
                             "description": "PCI ID of the GPU device, if available; 0 otherwise.",
+                            "type": "number"
+                        },
+                        {
+                            "name": "subSysId",
+                            "description": "Sub sys ID of the GPU, only available on Windows.",
+                            "optional": true,
+                            "type": "number"
+                        },
+                        {
+                            "name": "revision",
+                            "description": "Revision of the GPU, only available on Windows.",
+                            "optional": true,
                             "type": "number"
                         },
                         {
@@ -14040,11 +15171,6 @@
                     "type": "string"
                 },
                 {
-                    "id": "BrowserContextID",
-                    "experimental": true,
-                    "type": "string"
-                },
-                {
                     "id": "TargetInfo",
                     "type": "object",
                     "properties": [
@@ -14079,7 +15205,7 @@
                             "name": "browserContextId",
                             "experimental": true,
                             "optional": true,
-                            "$ref": "BrowserContextID"
+                            "$ref": "Browser.BrowserContextID"
                         }
                     ]
                 },
@@ -14120,8 +15246,7 @@
                         },
                         {
                             "name": "flatten",
-                            "description": "Enables \"flat\" access to the session via specifying sessionId attribute in the commands.",
-                            "experimental": true,
+                            "description": "Enables \"flat\" access to the session via specifying sessionId attribute in the commands.\nWe plan to make this the default, deprecate non-flattened mode,\nand eventually retire it. See crbug.com/991325.",
                             "optional": true,
                             "type": "boolean"
                         }
@@ -14183,11 +15308,19 @@
                     "name": "createBrowserContext",
                     "description": "Creates a new empty BrowserContext. Similar to an incognito profile but you can have more than\none.",
                     "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "disposeOnDetach",
+                            "description": "If specified, disposes this context when debugging session disconnects.",
+                            "optional": true,
+                            "type": "boolean"
+                        }
+                    ],
                     "returns": [
                         {
                             "name": "browserContextId",
                             "description": "The id of the context created.",
-                            "$ref": "BrowserContextID"
+                            "$ref": "Browser.BrowserContextID"
                         }
                     ]
                 },
@@ -14201,7 +15334,7 @@
                             "description": "An array of browser context ids.",
                             "type": "array",
                             "items": {
-                                "$ref": "BrowserContextID"
+                                "$ref": "Browser.BrowserContextID"
                             }
                         }
                     ]
@@ -14231,7 +15364,7 @@
                             "name": "browserContextId",
                             "description": "The browser context to create the page in.",
                             "optional": true,
-                            "$ref": "BrowserContextID"
+                            "$ref": "Browser.BrowserContextID"
                         },
                         {
                             "name": "enableBeginFrameControl",
@@ -14287,7 +15420,7 @@
                     "parameters": [
                         {
                             "name": "browserContextId",
-                            "$ref": "BrowserContextID"
+                            "$ref": "Browser.BrowserContextID"
                         }
                     ]
                 },
@@ -14325,7 +15458,8 @@
                 },
                 {
                     "name": "sendMessageToTarget",
-                    "description": "Sends protocol message over session with given id.",
+                    "description": "Sends protocol message over session with given id.\nConsider using flat mode instead; see commands attachToTarget, setAutoAttach,\nand crbug.com/991325.",
+                    "deprecated": true,
                     "parameters": [
                         {
                             "name": "message",
@@ -14363,8 +15497,7 @@
                         },
                         {
                             "name": "flatten",
-                            "description": "Enables \"flat\" access to the session via specifying sessionId attribute in the commands.",
-                            "experimental": true,
+                            "description": "Enables \"flat\" access to the session via specifying sessionId attribute in the commands.\nWe plan to make this the default, deprecate non-flattened mode,\nand eventually retire it. See crbug.com/991325.",
                             "optional": true,
                             "type": "boolean"
                         }
@@ -14691,6 +15824,14 @@
                 {
                     "name": "requestMemoryDump",
                     "description": "Request a global memory dump.",
+                    "parameters": [
+                        {
+                            "name": "deterministic",
+                            "description": "Enables more deterministic results by forcing garbage collection",
+                            "optional": true,
+                            "type": "boolean"
+                        }
+                    ],
                     "returns": [
                         {
                             "name": "dumpGuid",
@@ -15014,10 +16155,17 @@
                         {
                             "name": "responseHeaders",
                             "description": "Response headers.",
+                            "optional": true,
                             "type": "array",
                             "items": {
                                 "$ref": "HeaderEntry"
                             }
+                        },
+                        {
+                            "name": "binaryResponseHeaders",
+                            "description": "Alternative way of specifying response headers as a \\0-separated\nseries of name: value pairs. Prefer the above method unless you\nneed to represent some non-UTF8 values that can't be transmitted\nover the protocol as text.",
+                            "optional": true,
+                            "type": "string"
                         },
                         {
                             "name": "body",
@@ -15027,7 +16175,7 @@
                         },
                         {
                             "name": "responsePhrase",
-                            "description": "A textual representation of responseCode.\nIf absent, a standard phrase mathcing responseCode is used.",
+                            "description": "A textual representation of responseCode.\nIf absent, a standard phrase matching responseCode is used.",
                             "optional": true,
                             "type": "string"
                         }
@@ -15062,7 +16210,7 @@
                         },
                         {
                             "name": "headers",
-                            "description": "If set, overrides the request headrts.",
+                            "description": "If set, overrides the request headers.",
                             "optional": true,
                             "type": "array",
                             "items": {
@@ -15720,15 +16868,25 @@
                         },
                         {
                             "name": "hasResidentKey",
+                            "description": "Defaults to false.",
+                            "optional": true,
                             "type": "boolean"
                         },
                         {
                             "name": "hasUserVerification",
+                            "description": "Defaults to false.",
+                            "optional": true,
                             "type": "boolean"
                         },
                         {
                             "name": "automaticPresenceSimulation",
                             "description": "If set to true, tests of user presence will succeed immediately.\nOtherwise, they will not be resolved. Defaults to true.",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "isUserVerified",
+                            "description": "Sets whether User Verification succeeds or fails for an authenticator.\nDefaults to false.",
                             "optional": true,
                             "type": "boolean"
                         }
@@ -15914,50 +17072,73 @@
                     "type": "number"
                 },
                 {
-                    "id": "PlayerProperty",
-                    "description": "Player Property type",
+                    "id": "PlayerMessage",
+                    "description": "Have one type per entry in MediaLogRecord::Type\nCorresponds to kMessage",
                     "type": "object",
                     "properties": [
                         {
-                            "name": "name",
-                            "type": "string"
+                            "name": "level",
+                            "description": "Keep in sync with MediaLogMessageLevel\nWe are currently keeping the message level 'error' separate from the\nPlayerError type because right now they represent different things,\nthis one being a DVLOG(ERROR) style log message that gets printed\nbased on what log level is selected in the UI, and the other is a\nrepresentation of a media::PipelineStatus object. Soon however we're\ngoing to be moving away from using PipelineStatus for errors and\nintroducing a new error type which should hopefully let us integrate\nthe error log level into the PlayerError type.",
+                            "type": "string",
+                            "enum": [
+                                "error",
+                                "warning",
+                                "info",
+                                "debug"
+                            ]
                         },
                         {
-                            "name": "value",
-                            "optional": true,
+                            "name": "message",
                             "type": "string"
                         }
                     ]
                 },
                 {
-                    "id": "PlayerEventType",
-                    "description": "Break out events into different types",
-                    "type": "string",
-                    "enum": [
-                        "playbackEvent",
-                        "systemEvent",
-                        "messageEvent"
-                    ]
-                },
-                {
-                    "id": "PlayerEvent",
+                    "id": "PlayerProperty",
+                    "description": "Corresponds to kMediaPropertyChange",
                     "type": "object",
                     "properties": [
-                        {
-                            "name": "type",
-                            "$ref": "PlayerEventType"
-                        },
-                        {
-                            "name": "timestamp",
-                            "description": "Events are timestamped relative to the start of the player creation\nnot relative to the start of playback.",
-                            "$ref": "Timestamp"
-                        },
                         {
                             "name": "name",
                             "type": "string"
                         },
                         {
                             "name": "value",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "PlayerEvent",
+                    "description": "Corresponds to kMediaEventTriggered",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "timestamp",
+                            "$ref": "Timestamp"
+                        },
+                        {
+                            "name": "value",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "PlayerError",
+                    "description": "Corresponds to kMediaError",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "type",
+                            "type": "string",
+                            "enum": [
+                                "pipeline_error",
+                                "media_error"
+                            ]
+                        },
+                        {
+                            "name": "errorCode",
+                            "description": "When this switches to using media::Status instead of PipelineStatus\nwe can remove \"errorCode\" and replace it with the fields from\na Status instance. This also seems like a duplicate of the error\nlevel enum - there is a todo bug to have that level removed and\nuse this instead. (crbug.com/1068454)",
                             "type": "string"
                         }
                     ]
@@ -15994,6 +17175,40 @@
                             "type": "array",
                             "items": {
                                 "$ref": "PlayerEvent"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "playerMessagesLogged",
+                    "description": "Send a list of any messages that need to be delivered.",
+                    "parameters": [
+                        {
+                            "name": "playerId",
+                            "$ref": "PlayerId"
+                        },
+                        {
+                            "name": "messages",
+                            "type": "array",
+                            "items": {
+                                "$ref": "PlayerMessage"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "playerErrorsRaised",
+                    "description": "Send a list of any errors that need to be delivered.",
+                    "parameters": [
+                        {
+                            "name": "playerId",
+                            "$ref": "PlayerId"
+                        },
+                        {
+                            "name": "errors",
+                            "type": "array",
+                            "items": {
+                                "$ref": "PlayerError"
                             }
                         }
                     ]

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Audits.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Audits.java
@@ -20,9 +20,13 @@ package com.github.kklisura.cdt.protocol.commands;
  * #L%
  */
 
+import com.github.kklisura.cdt.protocol.events.audits.IssueAdded;
+import com.github.kklisura.cdt.protocol.support.annotations.EventName;
 import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
 import com.github.kklisura.cdt.protocol.support.annotations.Optional;
 import com.github.kklisura.cdt.protocol.support.annotations.ParamName;
+import com.github.kklisura.cdt.protocol.support.types.EventHandler;
+import com.github.kklisura.cdt.protocol.support.types.EventListener;
 import com.github.kklisura.cdt.protocol.types.audits.EncodedResponse;
 import com.github.kklisura.cdt.protocol.types.audits.GetEncodedResponseEncoding;
 
@@ -55,4 +59,16 @@ public interface Audits {
       @ParamName("encoding") GetEncodedResponseEncoding encoding,
       @Optional @ParamName("quality") Double quality,
       @Optional @ParamName("sizeOnly") Boolean sizeOnly);
+
+  /** Disables issues domain, prevents further issues from being reported to the client. */
+  void disable();
+
+  /**
+   * Enables issues domain, sends the issues collected so far to the client by means of the
+   * `issueAdded` event.
+   */
+  void enable();
+
+  @EventName("issueAdded")
+  EventListener onIssueAdded(EventHandler<IssueAdded> eventListener);
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Browser.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Browser.java
@@ -30,6 +30,7 @@ import com.github.kklisura.cdt.protocol.types.browser.Histogram;
 import com.github.kklisura.cdt.protocol.types.browser.PermissionDescriptor;
 import com.github.kklisura.cdt.protocol.types.browser.PermissionSetting;
 import com.github.kklisura.cdt.protocol.types.browser.PermissionType;
+import com.github.kklisura.cdt.protocol.types.browser.SetDownloadBehaviorBehavior;
 import com.github.kklisura.cdt.protocol.types.browser.Version;
 import com.github.kklisura.cdt.protocol.types.browser.WindowForTarget;
 import java.util.List;
@@ -40,54 +41,49 @@ public interface Browser {
   /**
    * Set permission settings for given origin.
    *
-   * @param origin Origin the permission applies to.
    * @param permission Descriptor of permission to override.
    * @param setting Setting of the permission.
    */
   @Experimental
   void setPermission(
-      @ParamName("origin") String origin,
       @ParamName("permission") PermissionDescriptor permission,
       @ParamName("setting") PermissionSetting setting);
 
   /**
    * Set permission settings for given origin.
    *
-   * @param origin Origin the permission applies to.
    * @param permission Descriptor of permission to override.
    * @param setting Setting of the permission.
+   * @param origin Origin the permission applies to, all origins if not specified.
    * @param browserContextId Context to override. When omitted, default browser context is used.
    */
   @Experimental
   void setPermission(
-      @ParamName("origin") String origin,
       @ParamName("permission") PermissionDescriptor permission,
       @ParamName("setting") PermissionSetting setting,
+      @Optional @ParamName("origin") String origin,
       @Optional @ParamName("browserContextId") String browserContextId);
 
   /**
    * Grant specific permissions to the given origin and reject all others.
    *
-   * @param origin
    * @param permissions
    */
   @Experimental
-  void grantPermissions(
-      @ParamName("origin") String origin,
-      @ParamName("permissions") List<PermissionType> permissions);
+  void grantPermissions(@ParamName("permissions") List<PermissionType> permissions);
 
   /**
    * Grant specific permissions to the given origin and reject all others.
    *
-   * @param origin
    * @param permissions
+   * @param origin Origin the permission applies to, all origins if not specified.
    * @param browserContextId BrowserContext to override permissions. When omitted, default browser
    *     context is used.
    */
   @Experimental
   void grantPermissions(
-      @ParamName("origin") String origin,
       @ParamName("permissions") List<PermissionType> permissions,
+      @Optional @ParamName("origin") String origin,
       @Optional @ParamName("browserContextId") String browserContextId);
 
   /** Reset all permission management for all origins. */
@@ -102,6 +98,33 @@ public interface Browser {
    */
   @Experimental
   void resetPermissions(@Optional @ParamName("browserContextId") String browserContextId);
+
+  /**
+   * Set the behavior when downloading a file.
+   *
+   * @param behavior Whether to allow all or deny all download requests, or use default Chrome
+   *     behavior if available (otherwise deny). |allowAndName| allows download and names files
+   *     according to their dowmload guids.
+   */
+  @Experimental
+  void setDownloadBehavior(@ParamName("behavior") SetDownloadBehaviorBehavior behavior);
+
+  /**
+   * Set the behavior when downloading a file.
+   *
+   * @param behavior Whether to allow all or deny all download requests, or use default Chrome
+   *     behavior if available (otherwise deny). |allowAndName| allows download and names files
+   *     according to their dowmload guids.
+   * @param browserContextId BrowserContext to set download behavior. When omitted, default browser
+   *     context is used.
+   * @param downloadPath The default path to save downloaded files to. This is requred if behavior
+   *     is set to 'allow' or 'allowAndName'.
+   */
+  @Experimental
+  void setDownloadBehavior(
+      @ParamName("behavior") SetDownloadBehaviorBehavior behavior,
+      @Optional @ParamName("browserContextId") String browserContextId,
+      @Optional @ParamName("downloadPath") String downloadPath);
 
   /** Close browser gracefully. */
   void close();

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/CSS.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/CSS.java
@@ -44,6 +44,7 @@ import com.github.kklisura.cdt.protocol.types.css.RuleUsage;
 import com.github.kklisura.cdt.protocol.types.css.SelectorList;
 import com.github.kklisura.cdt.protocol.types.css.SourceRange;
 import com.github.kklisura.cdt.protocol.types.css.StyleDeclarationEdit;
+import com.github.kklisura.cdt.protocol.types.css.TakeCoverageDelta;
 import com.github.kklisura.cdt.protocol.types.css.Value;
 import java.util.List;
 
@@ -245,9 +246,7 @@ public interface CSS {
    * Obtain list of rules that became used since last call to this method (or since start of
    * coverage instrumentation)
    */
-  @Returns("coverage")
-  @ReturnTypeParameter(RuleUsage.class)
-  List<RuleUsage> takeCoverageDelta();
+  TakeCoverageDelta takeCoverageDelta();
 
   /**
    * Fires whenever a web font is updated. A non-empty font parameter indicates a successfully

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/CacheStorage.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/CacheStorage.java
@@ -75,13 +75,8 @@ public interface CacheStorage {
    * Requests data from cache.
    *
    * @param cacheId ID of cache to get entries from.
-   * @param skipCount Number of records to skip.
-   * @param pageSize Number of records to fetch.
    */
-  RequestEntries requestEntries(
-      @ParamName("cacheId") String cacheId,
-      @ParamName("skipCount") Integer skipCount,
-      @ParamName("pageSize") Integer pageSize);
+  RequestEntries requestEntries(@ParamName("cacheId") String cacheId);
 
   /**
    * Requests data from cache.
@@ -93,7 +88,7 @@ public interface CacheStorage {
    */
   RequestEntries requestEntries(
       @ParamName("cacheId") String cacheId,
-      @ParamName("skipCount") Integer skipCount,
-      @ParamName("pageSize") Integer pageSize,
+      @Optional @ParamName("skipCount") Integer skipCount,
+      @Optional @ParamName("pageSize") Integer pageSize,
       @Optional @ParamName("pathFilter") String pathFilter);
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/DOM.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/DOM.java
@@ -47,6 +47,7 @@ import com.github.kklisura.cdt.protocol.types.dom.FrameOwner;
 import com.github.kklisura.cdt.protocol.types.dom.Node;
 import com.github.kklisura.cdt.protocol.types.dom.NodeForLocation;
 import com.github.kklisura.cdt.protocol.types.dom.PerformSearch;
+import com.github.kklisura.cdt.protocol.types.dom.Rect;
 import com.github.kklisura.cdt.protocol.types.runtime.RemoteObject;
 import com.github.kklisura.cdt.protocol.types.runtime.StackTrace;
 import java.util.List;
@@ -128,6 +129,30 @@ public interface DOM {
       @Optional @ParamName("objectId") String objectId,
       @Optional @ParamName("depth") Integer depth,
       @Optional @ParamName("pierce") Boolean pierce);
+
+  /**
+   * Scrolls the specified rect of the given node into view if not already visible. Note: exactly
+   * one between nodeId, backendNodeId and objectId should be passed to identify the node.
+   */
+  @Experimental
+  void scrollIntoViewIfNeeded();
+
+  /**
+   * Scrolls the specified rect of the given node into view if not already visible. Note: exactly
+   * one between nodeId, backendNodeId and objectId should be passed to identify the node.
+   *
+   * @param nodeId Identifier of the node.
+   * @param backendNodeId Identifier of the backend node.
+   * @param objectId JavaScript object id of the node wrapper.
+   * @param rect The rect to be scrolled into view, relative to the node's border box, in CSS
+   *     pixels. When omitted, center of the node will be used, similar to Element.scrollIntoView.
+   */
+  @Experimental
+  void scrollIntoViewIfNeeded(
+      @Optional @ParamName("nodeId") Integer nodeId,
+      @Optional @ParamName("backendNodeId") Integer backendNodeId,
+      @Optional @ParamName("objectId") String objectId,
+      @Optional @ParamName("rect") Rect rect);
 
   /** Disables DOM agent for the given page. */
   void disable();
@@ -251,7 +276,6 @@ public interface DOM {
    * @param x X coordinate.
    * @param y Y coordinate.
    */
-  @Experimental
   NodeForLocation getNodeForLocation(@ParamName("x") Integer x, @ParamName("y") Integer y);
 
   /**
@@ -262,12 +286,14 @@ public interface DOM {
    * @param y Y coordinate.
    * @param includeUserAgentShadowDOM False to skip to the nearest non-UA shadow root ancestor
    *     (default: false).
+   * @param ignorePointerEventsNone Whether to ignore pointer-events: none on elements and hit test
+   *     them.
    */
-  @Experimental
   NodeForLocation getNodeForLocation(
       @ParamName("x") Integer x,
       @ParamName("y") Integer y,
-      @Optional @ParamName("includeUserAgentShadowDOM") Boolean includeUserAgentShadowDOM);
+      @Optional @ParamName("includeUserAgentShadowDOM") Boolean includeUserAgentShadowDOM,
+      @Optional @ParamName("ignorePointerEventsNone") Boolean ignorePointerEventsNone);
 
   /** Returns node's HTML markup. */
   @Returns("outerHTML")

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Debugger.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Debugger.java
@@ -36,9 +36,11 @@ import com.github.kklisura.cdt.protocol.support.types.EventListener;
 import com.github.kklisura.cdt.protocol.types.debugger.BreakLocation;
 import com.github.kklisura.cdt.protocol.types.debugger.ContinueToLocationTargetCallFrames;
 import com.github.kklisura.cdt.protocol.types.debugger.EvaluateOnCallFrame;
+import com.github.kklisura.cdt.protocol.types.debugger.ExecuteWasmEvaluator;
 import com.github.kklisura.cdt.protocol.types.debugger.Location;
 import com.github.kklisura.cdt.protocol.types.debugger.RestartFrame;
 import com.github.kklisura.cdt.protocol.types.debugger.ScriptPosition;
+import com.github.kklisura.cdt.protocol.types.debugger.ScriptSource;
 import com.github.kklisura.cdt.protocol.types.debugger.SearchMatch;
 import com.github.kklisura.cdt.protocol.types.debugger.SetBreakpoint;
 import com.github.kklisura.cdt.protocol.types.debugger.SetBreakpointByUrl;
@@ -133,6 +135,29 @@ public interface Debugger {
       @Experimental @Optional @ParamName("timeout") Double timeout);
 
   /**
+   * Execute a Wasm Evaluator module on a given call frame.
+   *
+   * @param callFrameId WebAssembly call frame identifier to evaluate on.
+   * @param evaluator Code of the evaluator module.
+   */
+  @Experimental
+  ExecuteWasmEvaluator executeWasmEvaluator(
+      @ParamName("callFrameId") String callFrameId, @ParamName("evaluator") String evaluator);
+
+  /**
+   * Execute a Wasm Evaluator module on a given call frame.
+   *
+   * @param callFrameId WebAssembly call frame identifier to evaluate on.
+   * @param evaluator Code of the evaluator module.
+   * @param timeout Terminate execution after timing out (number of milliseconds).
+   */
+  @Experimental
+  ExecuteWasmEvaluator executeWasmEvaluator(
+      @ParamName("callFrameId") String callFrameId,
+      @ParamName("evaluator") String evaluator,
+      @Experimental @Optional @ParamName("timeout") Double timeout);
+
+  /**
    * Returns possible locations for breakpoint. scriptId in start and end range locations should be
    * the same.
    *
@@ -164,8 +189,16 @@ public interface Debugger {
    *
    * @param scriptId Id of the script to get source for.
    */
-  @Returns("scriptSource")
-  String getScriptSource(@ParamName("scriptId") String scriptId);
+  ScriptSource getScriptSource(@ParamName("scriptId") String scriptId);
+
+  /**
+   * This command is deprecated. Use getScriptSource instead.
+   *
+   * @param scriptId Id of the Wasm script to get source for.
+   */
+  @Deprecated
+  @Returns("bytecode")
+  String getWasmBytecode(@ParamName("scriptId") String scriptId);
 
   /**
    * Returns stack trace with given `stackTraceId`.
@@ -183,6 +216,7 @@ public interface Debugger {
    * @param parentStackTraceId Debugger will pause when async call with given stack trace is
    *     started.
    */
+  @Deprecated
   @Experimental
   void pauseOnAsyncCall(@ParamName("parentStackTraceId") StackTraceId parentStackTraceId);
 
@@ -202,6 +236,17 @@ public interface Debugger {
 
   /** Resumes JavaScript execution. */
   void resume();
+
+  /**
+   * Resumes JavaScript execution.
+   *
+   * @param terminateOnResume Set to true to terminate execution upon resuming execution. In
+   *     contrast to Runtime.terminateExecution, this will allows to execute further JavaScript
+   *     (i.e. via evaluation) until execution of the paused code is actually resumed, at which
+   *     point termination is triggered. If execution is currently not paused, this parameter has no
+   *     effect.
+   */
+  void resume(@Optional @ParamName("terminateOnResume") Boolean terminateOnResume);
 
   /**
    * Searches for given string in script content.
@@ -418,8 +463,8 @@ public interface Debugger {
   /**
    * Steps into the function call.
    *
-   * @param breakOnAsyncCall Debugger will issue additional Debugger.paused notification if any
-   *     async task is scheduled before next pause.
+   * @param breakOnAsyncCall Debugger will pause on the execution of the first async task which was
+   *     scheduled before next pause.
    */
   void stepInto(@Experimental @Optional @ParamName("breakOnAsyncCall") Boolean breakOnAsyncCall);
 

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Emulation.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Emulation.java
@@ -29,10 +29,14 @@ import com.github.kklisura.cdt.protocol.support.annotations.Returns;
 import com.github.kklisura.cdt.protocol.support.types.EventHandler;
 import com.github.kklisura.cdt.protocol.support.types.EventListener;
 import com.github.kklisura.cdt.protocol.types.dom.RGBA;
+import com.github.kklisura.cdt.protocol.types.emulation.MediaFeature;
 import com.github.kklisura.cdt.protocol.types.emulation.ScreenOrientation;
 import com.github.kklisura.cdt.protocol.types.emulation.SetEmitTouchEventsForMouseConfiguration;
+import com.github.kklisura.cdt.protocol.types.emulation.SetEmulatedVisionDeficiencyType;
+import com.github.kklisura.cdt.protocol.types.emulation.UserAgentMetadata;
 import com.github.kklisura.cdt.protocol.types.emulation.VirtualTimePolicy;
 import com.github.kklisura.cdt.protocol.types.page.Viewport;
+import java.util.List;
 
 /** This domain emulates different environments for the page. */
 public interface Emulation {
@@ -159,12 +163,26 @@ public interface Emulation {
       @ParamName("enabled") Boolean enabled,
       @Optional @ParamName("configuration") SetEmitTouchEventsForMouseConfiguration configuration);
 
+  /** Emulates the given media type or media feature for CSS media queries. */
+  void setEmulatedMedia();
+
   /**
-   * Emulates the given media for CSS media queries.
+   * Emulates the given media type or media feature for CSS media queries.
    *
    * @param media Media type to emulate. Empty string disables the override.
+   * @param features Media features to emulate.
    */
-  void setEmulatedMedia(@ParamName("media") String media);
+  void setEmulatedMedia(
+      @Optional @ParamName("media") String media,
+      @Optional @ParamName("features") List<MediaFeature> features);
+
+  /**
+   * Emulates the given vision deficiency.
+   *
+   * @param type Vision deficiency to emulate.
+   */
+  @Experimental
+  void setEmulatedVisionDeficiency(@ParamName("type") SetEmulatedVisionDeficiencyType type);
 
   /**
    * Overrides the Geolocation Position or Error. Omitting any of the parameters emulates position
@@ -260,6 +278,19 @@ public interface Emulation {
       @Optional @ParamName("waitForNavigation") Boolean waitForNavigation,
       @Optional @ParamName("initialVirtualTime") Double initialVirtualTime);
 
+  /** Overrides default host system locale with the specified one. */
+  @Experimental
+  void setLocaleOverride();
+
+  /**
+   * Overrides default host system locale with the specified one.
+   *
+   * @param locale ICU style C locale (e.g. "en_US"). If not specified or empty, disables the
+   *     override and restores default host system locale.
+   */
+  @Experimental
+  void setLocaleOverride(@Optional @ParamName("locale") String locale);
+
   /**
    * Overrides default host system timezone with the specified one.
    *
@@ -294,11 +325,14 @@ public interface Emulation {
    * @param userAgent User agent to use.
    * @param acceptLanguage Browser langugage to emulate.
    * @param platform The platform navigator.platform should return.
+   * @param userAgentMetadata To be sent in Sec-CH-UA-* headers and returned in
+   *     navigator.userAgentData
    */
   void setUserAgentOverride(
       @ParamName("userAgent") String userAgent,
       @Optional @ParamName("acceptLanguage") String acceptLanguage,
-      @Optional @ParamName("platform") String platform);
+      @Optional @ParamName("platform") String platform,
+      @Experimental @Optional @ParamName("userAgentMetadata") UserAgentMetadata userAgentMetadata);
 
   /**
    * Notification sent after the virtual time budget for the current VirtualTimePolicy has run out.

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Fetch.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Fetch.java
@@ -77,12 +77,9 @@ public interface Fetch {
    *
    * @param requestId An id the client received in requestPaused event.
    * @param responseCode An HTTP response code.
-   * @param responseHeaders Response headers.
    */
   void fulfillRequest(
-      @ParamName("requestId") String requestId,
-      @ParamName("responseCode") Integer responseCode,
-      @ParamName("responseHeaders") List<HeaderEntry> responseHeaders);
+      @ParamName("requestId") String requestId, @ParamName("responseCode") Integer responseCode);
 
   /**
    * Provides response to the request.
@@ -90,14 +87,18 @@ public interface Fetch {
    * @param requestId An id the client received in requestPaused event.
    * @param responseCode An HTTP response code.
    * @param responseHeaders Response headers.
+   * @param binaryResponseHeaders Alternative way of specifying response headers as a \0-separated
+   *     series of name: value pairs. Prefer the above method unless you need to represent some
+   *     non-UTF8 values that can't be transmitted over the protocol as text.
    * @param body A response body.
    * @param responsePhrase A textual representation of responseCode. If absent, a standard phrase
-   *     mathcing responseCode is used.
+   *     matching responseCode is used.
    */
   void fulfillRequest(
       @ParamName("requestId") String requestId,
       @ParamName("responseCode") Integer responseCode,
-      @ParamName("responseHeaders") List<HeaderEntry> responseHeaders,
+      @Optional @ParamName("responseHeaders") List<HeaderEntry> responseHeaders,
+      @Optional @ParamName("binaryResponseHeaders") String binaryResponseHeaders,
       @Optional @ParamName("body") String body,
       @Optional @ParamName("responsePhrase") String responsePhrase);
 
@@ -115,7 +116,7 @@ public interface Fetch {
    * @param url If set, the request url will be modified in a way that's not observable by page.
    * @param method If set, the request method is overridden.
    * @param postData If set, overrides the post data in the request.
-   * @param headers If set, overrides the request headrts.
+   * @param headers If set, overrides the request headers.
    */
   void continueRequest(
       @ParamName("requestId") String requestId,

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/HeadlessExperimental.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/HeadlessExperimental.java
@@ -72,7 +72,12 @@ public interface HeadlessExperimental {
   /** Enables headless events for the target. */
   void enable();
 
-  /** Issued when the target starts or stops needing BeginFrames. */
+  /**
+   * Issued when the target starts or stops needing BeginFrames. Deprecated. Issue beginFrame
+   * unconditionally instead and use result from beginFrame to detect whether the frames were
+   * suppressed.
+   */
   @EventName("needsBeginFramesChanged")
+  @Deprecated
   EventListener onNeedsBeginFramesChanged(EventHandler<NeedsBeginFramesChanged> eventListener);
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/HeapProfiler.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/HeapProfiler.java
@@ -93,16 +93,23 @@ public interface HeapProfiler {
   /**
    * @param reportProgress If true 'reportHeapSnapshotProgress' events will be generated while
    *     snapshot is being taken when the tracking is stopped.
+   * @param treatGlobalObjectsAsRoots
    */
-  void stopTrackingHeapObjects(@Optional @ParamName("reportProgress") Boolean reportProgress);
+  void stopTrackingHeapObjects(
+      @Optional @ParamName("reportProgress") Boolean reportProgress,
+      @Optional @ParamName("treatGlobalObjectsAsRoots") Boolean treatGlobalObjectsAsRoots);
 
   void takeHeapSnapshot();
 
   /**
    * @param reportProgress If true 'reportHeapSnapshotProgress' events will be generated while
    *     snapshot is being taken.
+   * @param treatGlobalObjectsAsRoots If true, a raw snapshot without artifical roots will be
+   *     generated
    */
-  void takeHeapSnapshot(@Optional @ParamName("reportProgress") Boolean reportProgress);
+  void takeHeapSnapshot(
+      @Optional @ParamName("reportProgress") Boolean reportProgress,
+      @Optional @ParamName("treatGlobalObjectsAsRoots") Boolean treatGlobalObjectsAsRoots);
 
   @EventName("addHeapSnapshotChunk")
   EventListener onAddHeapSnapshotChunk(EventHandler<AddHeapSnapshotChunk> eventListener);

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Input.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Input.java
@@ -24,13 +24,12 @@ import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
 import com.github.kklisura.cdt.protocol.support.annotations.Optional;
 import com.github.kklisura.cdt.protocol.support.annotations.ParamName;
 import com.github.kklisura.cdt.protocol.types.input.DispatchKeyEventType;
-import com.github.kklisura.cdt.protocol.types.input.DispatchMouseEventButton;
 import com.github.kklisura.cdt.protocol.types.input.DispatchMouseEventPointerType;
 import com.github.kklisura.cdt.protocol.types.input.DispatchMouseEventType;
 import com.github.kklisura.cdt.protocol.types.input.DispatchTouchEventType;
-import com.github.kklisura.cdt.protocol.types.input.EmulateTouchFromMouseEventButton;
 import com.github.kklisura.cdt.protocol.types.input.EmulateTouchFromMouseEventType;
 import com.github.kklisura.cdt.protocol.types.input.GestureSourceType;
+import com.github.kklisura.cdt.protocol.types.input.MouseButton;
 import com.github.kklisura.cdt.protocol.types.input.TouchPoint;
 import java.util.List;
 
@@ -130,7 +129,7 @@ public interface Input {
       @ParamName("y") Double y,
       @Optional @ParamName("modifiers") Integer modifiers,
       @Optional @ParamName("timestamp") Double timestamp,
-      @Optional @ParamName("button") DispatchMouseEventButton button,
+      @Optional @ParamName("button") MouseButton button,
       @Optional @ParamName("buttons") Integer buttons,
       @Optional @ParamName("clickCount") Integer clickCount,
       @Optional @ParamName("deltaX") Double deltaX,
@@ -174,14 +173,14 @@ public interface Input {
    * @param type Type of the mouse event.
    * @param x X coordinate of the mouse pointer in DIP.
    * @param y Y coordinate of the mouse pointer in DIP.
-   * @param button Mouse button.
+   * @param button Mouse button. Only "none", "left", "right" are supported.
    */
   @Experimental
   void emulateTouchFromMouseEvent(
       @ParamName("type") EmulateTouchFromMouseEventType type,
       @ParamName("x") Integer x,
       @ParamName("y") Integer y,
-      @ParamName("button") EmulateTouchFromMouseEventButton button);
+      @ParamName("button") MouseButton button);
 
   /**
    * Emulates touch event from the mouse event parameters.
@@ -189,7 +188,7 @@ public interface Input {
    * @param type Type of the mouse event.
    * @param x X coordinate of the mouse pointer in DIP.
    * @param y Y coordinate of the mouse pointer in DIP.
-   * @param button Mouse button.
+   * @param button Mouse button. Only "none", "left", "right" are supported.
    * @param timestamp Time at which the event occurred (default: current time).
    * @param deltaX X delta in DIP for mouse wheel event (default: 0).
    * @param deltaY Y delta in DIP for mouse wheel event (default: 0).
@@ -202,7 +201,7 @@ public interface Input {
       @ParamName("type") EmulateTouchFromMouseEventType type,
       @ParamName("x") Integer x,
       @ParamName("y") Integer y,
-      @ParamName("button") EmulateTouchFromMouseEventButton button,
+      @ParamName("button") MouseButton button,
       @Optional @ParamName("timestamp") Double timestamp,
       @Optional @ParamName("deltaX") Double deltaX,
       @Optional @ParamName("deltaY") Double deltaY,

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/LayerTree.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/LayerTree.java
@@ -31,6 +31,7 @@ import com.github.kklisura.cdt.protocol.support.annotations.Returns;
 import com.github.kklisura.cdt.protocol.support.types.EventHandler;
 import com.github.kklisura.cdt.protocol.support.types.EventListener;
 import com.github.kklisura.cdt.protocol.types.dom.Rect;
+import com.github.kklisura.cdt.protocol.types.layertree.CompositingReasons;
 import com.github.kklisura.cdt.protocol.types.layertree.PictureTile;
 import java.util.List;
 
@@ -42,9 +43,7 @@ public interface LayerTree {
    *
    * @param layerId The id of the layer for which we want to get the reasons it was composited.
    */
-  @Returns("compositingReasons")
-  @ReturnTypeParameter(String.class)
-  List<String> compositingReasons(@ParamName("layerId") String layerId);
+  CompositingReasons compositingReasons(@ParamName("layerId") String layerId);
 
   /** Disables compositing tree inspection. */
   void disable();

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Media.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Media.java
@@ -20,7 +20,9 @@ package com.github.kklisura.cdt.protocol.commands;
  * #L%
  */
 
+import com.github.kklisura.cdt.protocol.events.media.PlayerErrorsRaised;
 import com.github.kklisura.cdt.protocol.events.media.PlayerEventsAdded;
+import com.github.kklisura.cdt.protocol.events.media.PlayerMessagesLogged;
 import com.github.kklisura.cdt.protocol.events.media.PlayerPropertiesChanged;
 import com.github.kklisura.cdt.protocol.events.media.PlayersCreated;
 import com.github.kklisura.cdt.protocol.support.annotations.EventName;
@@ -51,6 +53,14 @@ public interface Media {
    */
   @EventName("playerEventsAdded")
   EventListener onPlayerEventsAdded(EventHandler<PlayerEventsAdded> eventListener);
+
+  /** Send a list of any messages that need to be delivered. */
+  @EventName("playerMessagesLogged")
+  EventListener onPlayerMessagesLogged(EventHandler<PlayerMessagesLogged> eventListener);
+
+  /** Send a list of any errors that need to be delivered. */
+  @EventName("playerErrorsRaised")
+  EventListener onPlayerErrorsRaised(EventHandler<PlayerErrorsRaised> eventListener);
 
   /**
    * Called whenever a player is created, or when a new agent joins and recieves a list of active

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Network.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Network.java
@@ -52,6 +52,7 @@ import com.github.kklisura.cdt.protocol.types.network.AuthChallengeResponse;
 import com.github.kklisura.cdt.protocol.types.network.ConnectionType;
 import com.github.kklisura.cdt.protocol.types.network.Cookie;
 import com.github.kklisura.cdt.protocol.types.network.CookieParam;
+import com.github.kklisura.cdt.protocol.types.network.CookiePriority;
 import com.github.kklisura.cdt.protocol.types.network.CookieSameSite;
 import com.github.kklisura.cdt.protocol.types.network.ErrorReason;
 import com.github.kklisura.cdt.protocol.types.network.RequestPattern;
@@ -372,6 +373,7 @@ public interface Network {
    * @param httpOnly True if cookie is http-only.
    * @param sameSite Cookie SameSite type.
    * @param expires Cookie expiration date, session cookie if not set
+   * @param priority Cookie Priority type.
    */
   @Returns("success")
   Boolean setCookie(
@@ -383,7 +385,8 @@ public interface Network {
       @Optional @ParamName("secure") Boolean secure,
       @Optional @ParamName("httpOnly") Boolean httpOnly,
       @Optional @ParamName("sameSite") CookieSameSite sameSite,
-      @Optional @ParamName("expires") Double expires);
+      @Optional @ParamName("expires") Double expires,
+      @Experimental @Optional @ParamName("priority") CookiePriority priority);
 
   /**
    * Sets given cookies.

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Overlay.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Overlay.java
@@ -32,7 +32,9 @@ import com.github.kklisura.cdt.protocol.support.annotations.Returns;
 import com.github.kklisura.cdt.protocol.support.types.EventHandler;
 import com.github.kklisura.cdt.protocol.support.types.EventListener;
 import com.github.kklisura.cdt.protocol.types.dom.RGBA;
+import com.github.kklisura.cdt.protocol.types.overlay.ColorFormat;
 import com.github.kklisura.cdt.protocol.types.overlay.HighlightConfig;
+import com.github.kklisura.cdt.protocol.types.overlay.HingeConfig;
 import com.github.kklisura.cdt.protocol.types.overlay.InspectMode;
 import java.util.List;
 import java.util.Map;
@@ -61,12 +63,14 @@ public interface Overlay {
    * @param nodeId Id of the node to get highlight object for.
    * @param includeDistance Whether to include distance info.
    * @param includeStyle Whether to include style info.
+   * @param colorFormat The color format to get config with (default: hex)
    */
   @Returns("highlight")
   Map<String, Object> getHighlightObjectForTest(
       @ParamName("nodeId") Integer nodeId,
       @Optional @ParamName("includeDistance") Boolean includeDistance,
-      @Optional @ParamName("includeStyle") Boolean includeStyle);
+      @Optional @ParamName("includeStyle") Boolean includeStyle,
+      @Optional @ParamName("colorFormat") ColorFormat colorFormat);
 
   /** Hides any highlight. */
   void hideHighlight();
@@ -246,6 +250,16 @@ public interface Overlay {
    * @param show Whether to paint size or not.
    */
   void setShowViewportSizeOnResize(@ParamName("show") Boolean show);
+
+  /** Add a dual screen device hinge */
+  void setShowHinge();
+
+  /**
+   * Add a dual screen device hinge
+   *
+   * @param hingeConfig hinge data, null means hideHinge
+   */
+  void setShowHinge(@Optional @ParamName("hingeConfig") HingeConfig hingeConfig);
 
   /**
    * Fired when the node should be inspected. This happens after call to `setInspectMode` or when

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Page.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Page.java
@@ -22,6 +22,7 @@ package com.github.kklisura.cdt.protocol.commands;
 
 import com.github.kklisura.cdt.protocol.events.page.CompilationCacheProduced;
 import com.github.kklisura.cdt.protocol.events.page.DomContentEventFired;
+import com.github.kklisura.cdt.protocol.events.page.DownloadProgress;
 import com.github.kklisura.cdt.protocol.events.page.DownloadWillBegin;
 import com.github.kklisura.cdt.protocol.events.page.FileChooserOpened;
 import com.github.kklisura.cdt.protocol.events.page.FrameAttached;
@@ -59,12 +60,13 @@ import com.github.kklisura.cdt.protocol.types.page.FontFamilies;
 import com.github.kklisura.cdt.protocol.types.page.FontSizes;
 import com.github.kklisura.cdt.protocol.types.page.FrameResourceTree;
 import com.github.kklisura.cdt.protocol.types.page.FrameTree;
-import com.github.kklisura.cdt.protocol.types.page.HandleFileChooserAction;
+import com.github.kklisura.cdt.protocol.types.page.InstallabilityError;
 import com.github.kklisura.cdt.protocol.types.page.LayoutMetrics;
 import com.github.kklisura.cdt.protocol.types.page.Navigate;
 import com.github.kklisura.cdt.protocol.types.page.NavigationHistory;
 import com.github.kklisura.cdt.protocol.types.page.PrintToPDF;
 import com.github.kklisura.cdt.protocol.types.page.PrintToPDFTransferMode;
+import com.github.kklisura.cdt.protocol.types.page.ReferrerPolicy;
 import com.github.kklisura.cdt.protocol.types.page.ResourceContent;
 import com.github.kklisura.cdt.protocol.types.page.SetDownloadBehaviorBehavior;
 import com.github.kklisura.cdt.protocol.types.page.SetWebLifecycleStateState;
@@ -179,9 +181,13 @@ public interface Page {
   AppManifest getAppManifest();
 
   @Experimental
-  @Returns("errors")
-  @ReturnTypeParameter(String.class)
-  List<String> getInstallabilityErrors();
+  @Returns("installabilityErrors")
+  @ReturnTypeParameter(InstallabilityError.class)
+  List<InstallabilityError> getInstallabilityErrors();
+
+  @Experimental
+  @Returns("primaryIcon")
+  String getManifestIcons();
 
   /** Returns present frame tree structure. */
   @Returns("frameTree")
@@ -242,12 +248,14 @@ public interface Page {
    * @param referrer Referrer URL.
    * @param transitionType Intended transition type.
    * @param frameId Frame id to navigate, if not specified navigates the top frame.
+   * @param referrerPolicy Referrer-policy used for the navigation.
    */
   Navigate navigate(
       @ParamName("url") String url,
       @Optional @ParamName("referrer") String referrer,
       @Optional @ParamName("transitionType") TransitionType transitionType,
-      @Optional @ParamName("frameId") String frameId);
+      @Optional @ParamName("frameId") String frameId,
+      @Experimental @Optional @ParamName("referrerPolicy") ReferrerPolicy referrerPolicy);
 
   /**
    * Navigates current page to the given history entry.
@@ -425,6 +433,7 @@ public interface Page {
    * @param behavior Whether to allow all or deny all download requests, or use default Chrome
    *     behavior if available (otherwise deny).
    */
+  @Deprecated
   @Experimental
   void setDownloadBehavior(@ParamName("behavior") SetDownloadBehaviorBehavior behavior);
 
@@ -436,6 +445,7 @@ public interface Page {
    * @param downloadPath The default path to save downloaded files to. This is requred if behavior
    *     is set to 'allow'
    */
+  @Deprecated
   @Experimental
   void setDownloadBehavior(
       @ParamName("behavior") SetDownloadBehaviorBehavior behavior,
@@ -541,32 +551,12 @@ public interface Page {
   /**
    * Intercept file chooser requests and transfer control to protocol clients. When file chooser
    * interception is enabled, native file chooser dialog is not shown. Instead, a protocol event
-   * `Page.fileChooserOpened` is emitted. File chooser can be handled with `page.handleFileChooser`
-   * command.
+   * `Page.fileChooserOpened` is emitted.
    *
    * @param enabled
    */
   @Experimental
   void setInterceptFileChooserDialog(@ParamName("enabled") Boolean enabled);
-
-  /**
-   * Accepts or cancels an intercepted file chooser dialog.
-   *
-   * @param action
-   */
-  @Experimental
-  void handleFileChooser(@ParamName("action") HandleFileChooserAction action);
-
-  /**
-   * Accepts or cancels an intercepted file chooser dialog.
-   *
-   * @param action
-   * @param files Array of absolute file paths to set, only respected with `accept` action.
-   */
-  @Experimental
-  void handleFileChooser(
-      @ParamName("action") HandleFileChooserAction action,
-      @Optional @ParamName("files") List<String> files);
 
   @EventName("domContentEventFired")
   EventListener onDomContentEventFired(EventHandler<DomContentEventFired> eventListener);
@@ -626,6 +616,11 @@ public interface Page {
   @EventName("downloadWillBegin")
   @Experimental
   EventListener onDownloadWillBegin(EventHandler<DownloadWillBegin> eventListener);
+
+  /** Fired when download makes progress. Last call has |done| == true. */
+  @EventName("downloadProgress")
+  @Experimental
+  EventListener onDownloadProgress(EventHandler<DownloadProgress> eventListener);
 
   /** Fired when interstitial page was hidden */
   @EventName("interstitialHidden")

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Performance.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Performance.java
@@ -23,11 +23,13 @@ package com.github.kklisura.cdt.protocol.commands;
 import com.github.kklisura.cdt.protocol.events.performance.Metrics;
 import com.github.kklisura.cdt.protocol.support.annotations.EventName;
 import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
+import com.github.kklisura.cdt.protocol.support.annotations.Optional;
 import com.github.kklisura.cdt.protocol.support.annotations.ParamName;
 import com.github.kklisura.cdt.protocol.support.annotations.ReturnTypeParameter;
 import com.github.kklisura.cdt.protocol.support.annotations.Returns;
 import com.github.kklisura.cdt.protocol.support.types.EventHandler;
 import com.github.kklisura.cdt.protocol.support.types.EventListener;
+import com.github.kklisura.cdt.protocol.types.performance.EnableTimeDomain;
 import com.github.kklisura.cdt.protocol.types.performance.Metric;
 import com.github.kklisura.cdt.protocol.types.performance.SetTimeDomainTimeDomain;
 import java.util.List;
@@ -41,12 +43,20 @@ public interface Performance {
   void enable();
 
   /**
+   * Enable collecting and reporting metrics.
+   *
+   * @param timeDomain Time domain to use for collecting and reporting duration metrics.
+   */
+  void enable(@Optional @ParamName("timeDomain") EnableTimeDomain timeDomain);
+
+  /**
    * Sets time domain to use for collecting and reporting duration metrics. Note that this must be
    * called before enabling metrics collection. Calling this method while metrics collection is
    * enabled returns an error.
    *
    * @param timeDomain Time domain
    */
+  @Deprecated
   @Experimental
   void setTimeDomain(@ParamName("timeDomain") SetTimeDomainTimeDomain timeDomain);
 

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Runtime.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Runtime.java
@@ -183,8 +183,12 @@ public interface Runtime {
    * @param awaitPromise Whether execution should `await` for resulting value and return once
    *     awaited promise is resolved.
    * @param throwOnSideEffect Whether to throw an exception if side effect cannot be ruled out
-   *     during evaluation.
+   *     during evaluation. This implies `disableBreaks` below.
    * @param timeout Terminate execution after timing out (number of milliseconds).
+   * @param disableBreaks Disable breakpoints during execution.
+   * @param replMode Setting this flag to true enables `let` re-declaration and top-level `await`.
+   *     Note that `let` variables can only be re-declared if they originate from `replMode`
+   *     themselves.
    */
   Evaluate evaluate(
       @ParamName("expression") String expression,
@@ -197,7 +201,9 @@ public interface Runtime {
       @Optional @ParamName("userGesture") Boolean userGesture,
       @Optional @ParamName("awaitPromise") Boolean awaitPromise,
       @Experimental @Optional @ParamName("throwOnSideEffect") Boolean throwOnSideEffect,
-      @Experimental @Optional @ParamName("timeout") Double timeout);
+      @Experimental @Optional @ParamName("timeout") Double timeout,
+      @Experimental @Optional @ParamName("disableBreaks") Boolean disableBreaks,
+      @Experimental @Optional @ParamName("replMode") Boolean replMode);
 
   /** Returns the isolate id. */
   @Experimental

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Security.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Security.java
@@ -22,6 +22,7 @@ package com.github.kklisura.cdt.protocol.commands;
 
 import com.github.kklisura.cdt.protocol.events.security.CertificateError;
 import com.github.kklisura.cdt.protocol.events.security.SecurityStateChanged;
+import com.github.kklisura.cdt.protocol.events.security.VisibleSecurityStateChanged;
 import com.github.kklisura.cdt.protocol.support.annotations.EventName;
 import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
 import com.github.kklisura.cdt.protocol.support.annotations.ParamName;
@@ -75,6 +76,12 @@ public interface Security {
   @EventName("certificateError")
   @Deprecated
   EventListener onCertificateError(EventHandler<CertificateError> eventListener);
+
+  /** The security state of the page changed. */
+  @EventName("visibleSecurityStateChanged")
+  @Experimental
+  EventListener onVisibleSecurityStateChanged(
+      EventHandler<VisibleSecurityStateChanged> eventListener);
 
   /** The security state of the page changed. */
   @EventName("securityStateChanged")

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Storage.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Storage.java
@@ -26,10 +26,16 @@ import com.github.kklisura.cdt.protocol.events.storage.IndexedDBContentUpdated;
 import com.github.kklisura.cdt.protocol.events.storage.IndexedDBListUpdated;
 import com.github.kklisura.cdt.protocol.support.annotations.EventName;
 import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
+import com.github.kklisura.cdt.protocol.support.annotations.Optional;
 import com.github.kklisura.cdt.protocol.support.annotations.ParamName;
+import com.github.kklisura.cdt.protocol.support.annotations.ReturnTypeParameter;
+import com.github.kklisura.cdt.protocol.support.annotations.Returns;
 import com.github.kklisura.cdt.protocol.support.types.EventHandler;
 import com.github.kklisura.cdt.protocol.support.types.EventListener;
+import com.github.kklisura.cdt.protocol.types.network.Cookie;
+import com.github.kklisura.cdt.protocol.types.network.CookieParam;
 import com.github.kklisura.cdt.protocol.types.storage.UsageAndQuota;
+import java.util.List;
 
 @Experimental
 public interface Storage {
@@ -42,6 +48,47 @@ public interface Storage {
    */
   void clearDataForOrigin(
       @ParamName("origin") String origin, @ParamName("storageTypes") String storageTypes);
+
+  /** Returns all browser cookies. */
+  @Returns("cookies")
+  @ReturnTypeParameter(Cookie.class)
+  List<Cookie> getCookies();
+
+  /**
+   * Returns all browser cookies.
+   *
+   * @param browserContextId Browser context to use when called on the browser endpoint.
+   */
+  @Returns("cookies")
+  @ReturnTypeParameter(Cookie.class)
+  List<Cookie> getCookies(@Optional @ParamName("browserContextId") String browserContextId);
+
+  /**
+   * Sets given cookies.
+   *
+   * @param cookies Cookies to be set.
+   */
+  void setCookies(@ParamName("cookies") List<CookieParam> cookies);
+
+  /**
+   * Sets given cookies.
+   *
+   * @param cookies Cookies to be set.
+   * @param browserContextId Browser context to use when called on the browser endpoint.
+   */
+  void setCookies(
+      @ParamName("cookies") List<CookieParam> cookies,
+      @Optional @ParamName("browserContextId") String browserContextId);
+
+  /** Clears cookies. */
+  void clearCookies();
+
+  /**
+   * Clears cookies.
+   *
+   * @param browserContextId Browser context to use when called on the browser endpoint.
+   */
+  void clearCookies(@Optional @ParamName("browserContextId") String browserContextId);
 
   /**
    * Returns usage and quota in bytes.

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Target.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Target.java
@@ -62,12 +62,12 @@ public interface Target {
    *
    * @param targetId
    * @param flatten Enables "flat" access to the session via specifying sessionId attribute in the
-   *     commands.
+   *     commands. We plan to make this the default, deprecate non-flattened mode, and eventually
+   *     retire it. See crbug.com/991325.
    */
   @Returns("sessionId")
   String attachToTarget(
-      @ParamName("targetId") String targetId,
-      @Experimental @Optional @ParamName("flatten") Boolean flatten);
+      @ParamName("targetId") String targetId, @Optional @ParamName("flatten") Boolean flatten);
 
   /** Attaches to the browser target, only uses flat sessionId mode. */
   @Experimental
@@ -122,6 +122,16 @@ public interface Target {
   @Experimental
   @Returns("browserContextId")
   String createBrowserContext();
+
+  /**
+   * Creates a new empty BrowserContext. Similar to an incognito profile but you can have more than
+   * one.
+   *
+   * @param disposeOnDetach If specified, disposes this context when debugging session disconnects.
+   */
+  @Experimental
+  @Returns("browserContextId")
+  String createBrowserContext(@Optional @ParamName("disposeOnDetach") Boolean disposeOnDetach);
 
   /** Returns all browser contexts created with `Target.createBrowserContext` method. */
   @Experimental
@@ -202,19 +212,23 @@ public interface Target {
   List<TargetInfo> getTargets();
 
   /**
-   * Sends protocol message over session with given id.
+   * Sends protocol message over session with given id. Consider using flat mode instead; see
+   * commands attachToTarget, setAutoAttach, and crbug.com/991325.
    *
    * @param message
    */
+  @Deprecated
   void sendMessageToTarget(@ParamName("message") String message);
 
   /**
-   * Sends protocol message over session with given id.
+   * Sends protocol message over session with given id. Consider using flat mode instead; see
+   * commands attachToTarget, setAutoAttach, and crbug.com/991325.
    *
    * @param message
    * @param sessionId Identifier of the session.
    * @param targetId Deprecated.
    */
+  @Deprecated
   void sendMessageToTarget(
       @ParamName("message") String message,
       @Optional @ParamName("sessionId") String sessionId,
@@ -243,13 +257,14 @@ public interface Target {
    * @param waitForDebuggerOnStart Whether to pause new targets when attaching to them. Use
    *     `Runtime.runIfWaitingForDebugger` to run paused targets.
    * @param flatten Enables "flat" access to the session via specifying sessionId attribute in the
-   *     commands.
+   *     commands. We plan to make this the default, deprecate non-flattened mode, and eventually
+   *     retire it. See crbug.com/991325.
    */
   @Experimental
   void setAutoAttach(
       @ParamName("autoAttach") Boolean autoAttach,
       @ParamName("waitForDebuggerOnStart") Boolean waitForDebuggerOnStart,
-      @Experimental @Optional @ParamName("flatten") Boolean flatten);
+      @Optional @ParamName("flatten") Boolean flatten);
 
   /**
    * Controls whether to discover available targets and notify via

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Tracing.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/commands/Tracing.java
@@ -59,6 +59,13 @@ public interface Tracing {
   /** Request a global memory dump. */
   RequestMemoryDump requestMemoryDump();
 
+  /**
+   * Request a global memory dump.
+   *
+   * @param deterministic Enables more deterministic results by forcing garbage collection
+   */
+  RequestMemoryDump requestMemoryDump(@Optional @ParamName("deterministic") Boolean deterministic);
+
   /** Start trace events collection. */
   void start();
 

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/audits/IssueAdded.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/audits/IssueAdded.java
@@ -1,0 +1,36 @@
+package com.github.kklisura.cdt.protocol.events.audits;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.types.audits.InspectorIssue;
+
+public class IssueAdded {
+
+  private InspectorIssue issue;
+
+  public InspectorIssue getIssue() {
+    return issue;
+  }
+
+  public void setIssue(InspectorIssue issue) {
+    this.issue = issue;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/debugger/Paused.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/debugger/Paused.java
@@ -43,7 +43,7 @@ public class Paused {
 
   @Experimental @Optional private StackTraceId asyncStackTraceId;
 
-  @Experimental @Optional private StackTraceId asyncCallStackTraceId;
+  @Deprecated @Experimental @Optional private StackTraceId asyncCallStackTraceId;
 
   /** Call stack the virtual machine stopped on. */
   public List<CallFrame> getCallFrames() {
@@ -105,18 +105,12 @@ public class Paused {
     this.asyncStackTraceId = asyncStackTraceId;
   }
 
-  /**
-   * Just scheduled async call will have this stack trace as parent stack during async execution.
-   * This field is available only after `Debugger.stepInto` call with `breakOnAsynCall` flag.
-   */
+  /** Never present, will be removed. */
   public StackTraceId getAsyncCallStackTraceId() {
     return asyncCallStackTraceId;
   }
 
-  /**
-   * Just scheduled async call will have this stack trace as parent stack during async execution.
-   * This field is available only after `Debugger.stepInto` call with `breakOnAsynCall` flag.
-   */
+  /** Never present, will be removed. */
   public void setAsyncCallStackTraceId(StackTraceId asyncCallStackTraceId) {
     this.asyncCallStackTraceId = asyncCallStackTraceId;
   }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/debugger/ScriptFailedToParse.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/debugger/ScriptFailedToParse.java
@@ -22,6 +22,7 @@ package com.github.kklisura.cdt.protocol.events.debugger;
 
 import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
 import com.github.kklisura.cdt.protocol.support.annotations.Optional;
+import com.github.kklisura.cdt.protocol.types.debugger.ScriptLanguage;
 import com.github.kklisura.cdt.protocol.types.runtime.StackTrace;
 import java.util.Map;
 
@@ -55,6 +56,10 @@ public class ScriptFailedToParse {
   @Optional private Integer length;
 
   @Experimental @Optional private StackTrace stackTrace;
+
+  @Experimental @Optional private Integer codeOffset;
+
+  @Experimental @Optional private ScriptLanguage scriptLanguage;
 
   /** Identifier of the script parsed. */
   public String getScriptId() {
@@ -194,5 +199,25 @@ public class ScriptFailedToParse {
   /** JavaScript top stack frame of where the script parsed event was triggered if available. */
   public void setStackTrace(StackTrace stackTrace) {
     this.stackTrace = stackTrace;
+  }
+
+  /** If the scriptLanguage is WebAssembly, the code section offset in the module. */
+  public Integer getCodeOffset() {
+    return codeOffset;
+  }
+
+  /** If the scriptLanguage is WebAssembly, the code section offset in the module. */
+  public void setCodeOffset(Integer codeOffset) {
+    this.codeOffset = codeOffset;
+  }
+
+  /** The language of the script. */
+  public ScriptLanguage getScriptLanguage() {
+    return scriptLanguage;
+  }
+
+  /** The language of the script. */
+  public void setScriptLanguage(ScriptLanguage scriptLanguage) {
+    this.scriptLanguage = scriptLanguage;
   }
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/debugger/ScriptParsed.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/debugger/ScriptParsed.java
@@ -22,6 +22,8 @@ package com.github.kklisura.cdt.protocol.events.debugger;
 
 import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
 import com.github.kklisura.cdt.protocol.support.annotations.Optional;
+import com.github.kklisura.cdt.protocol.types.debugger.DebugSymbols;
+import com.github.kklisura.cdt.protocol.types.debugger.ScriptLanguage;
 import com.github.kklisura.cdt.protocol.types.runtime.StackTrace;
 import java.util.Map;
 
@@ -60,6 +62,12 @@ public class ScriptParsed {
   @Optional private Integer length;
 
   @Experimental @Optional private StackTrace stackTrace;
+
+  @Experimental @Optional private Integer codeOffset;
+
+  @Experimental @Optional private ScriptLanguage scriptLanguage;
+
+  @Experimental @Optional private DebugSymbols debugSymbols;
 
   /** Identifier of the script parsed. */
   public String getScriptId() {
@@ -209,5 +217,35 @@ public class ScriptParsed {
   /** JavaScript top stack frame of where the script parsed event was triggered if available. */
   public void setStackTrace(StackTrace stackTrace) {
     this.stackTrace = stackTrace;
+  }
+
+  /** If the scriptLanguage is WebAssembly, the code section offset in the module. */
+  public Integer getCodeOffset() {
+    return codeOffset;
+  }
+
+  /** If the scriptLanguage is WebAssembly, the code section offset in the module. */
+  public void setCodeOffset(Integer codeOffset) {
+    this.codeOffset = codeOffset;
+  }
+
+  /** The language of the script. */
+  public ScriptLanguage getScriptLanguage() {
+    return scriptLanguage;
+  }
+
+  /** The language of the script. */
+  public void setScriptLanguage(ScriptLanguage scriptLanguage) {
+    this.scriptLanguage = scriptLanguage;
+  }
+
+  /** If the scriptLanguage is WebASsembly, the source of debug symbols for the module. */
+  public DebugSymbols getDebugSymbols() {
+    return debugSymbols;
+  }
+
+  /** If the scriptLanguage is WebASsembly, the source of debug symbols for the module. */
+  public void setDebugSymbols(DebugSymbols debugSymbols) {
+    this.debugSymbols = debugSymbols;
   }
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/headlessexperimental/NeedsBeginFramesChanged.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/headlessexperimental/NeedsBeginFramesChanged.java
@@ -20,7 +20,12 @@ package com.github.kklisura.cdt.protocol.events.headlessexperimental;
  * #L%
  */
 
-/** Issued when the target starts or stops needing BeginFrames. */
+/**
+ * Issued when the target starts or stops needing BeginFrames. Deprecated. Issue beginFrame
+ * unconditionally instead and use result from beginFrame to detect whether the frames were
+ * suppressed.
+ */
+@Deprecated
 public class NeedsBeginFramesChanged {
 
   private Boolean needsBeginFrames;

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/media/PlayerErrorsRaised.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/media/PlayerErrorsRaised.java
@@ -1,0 +1,48 @@
+package com.github.kklisura.cdt.protocol.events.media;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.types.media.PlayerError;
+import java.util.List;
+
+/** Send a list of any errors that need to be delivered. */
+public class PlayerErrorsRaised {
+
+  private String playerId;
+
+  private List<PlayerError> errors;
+
+  public String getPlayerId() {
+    return playerId;
+  }
+
+  public void setPlayerId(String playerId) {
+    this.playerId = playerId;
+  }
+
+  public List<PlayerError> getErrors() {
+    return errors;
+  }
+
+  public void setErrors(List<PlayerError> errors) {
+    this.errors = errors;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/media/PlayerMessagesLogged.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/media/PlayerMessagesLogged.java
@@ -1,4 +1,4 @@
-package com.github.kklisura.cdt.protocol.types.media;
+package com.github.kklisura.cdt.protocol.events.media;
 
 /*-
  * #%L
@@ -20,14 +20,29 @@ package com.github.kklisura.cdt.protocol.types.media;
  * #L%
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.kklisura.cdt.protocol.types.media.PlayerMessage;
+import java.util.List;
 
-/** Break out events into different types */
-public enum PlayerEventType {
-  @JsonProperty("playbackEvent")
-  PLAYBACK_EVENT,
-  @JsonProperty("systemEvent")
-  SYSTEM_EVENT,
-  @JsonProperty("messageEvent")
-  MESSAGE_EVENT
+/** Send a list of any messages that need to be delivered. */
+public class PlayerMessagesLogged {
+
+  private String playerId;
+
+  private List<PlayerMessage> messages;
+
+  public String getPlayerId() {
+    return playerId;
+  }
+
+  public void setPlayerId(String playerId) {
+    this.playerId = playerId;
+  }
+
+  public List<PlayerMessage> getMessages() {
+    return messages;
+  }
+
+  public void setMessages(List<PlayerMessage> messages) {
+    this.messages = messages;
+  }
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/network/RequestWillBeSentExtraInfo.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/network/RequestWillBeSentExtraInfo.java
@@ -36,7 +36,7 @@ public class RequestWillBeSentExtraInfo {
 
   private String requestId;
 
-  private List<BlockedCookieWithReason> blockedCookies;
+  private List<BlockedCookieWithReason> associatedCookies;
 
   private Map<String, Object> headers;
 
@@ -51,19 +51,21 @@ public class RequestWillBeSentExtraInfo {
   }
 
   /**
-   * A list of cookies which will not be sent with this request along with corresponding reasons for
-   * blocking.
+   * A list of cookies potentially associated to the requested URL. This includes both cookies sent
+   * with the request and the ones not sent; the latter are distinguished by having blockedReason
+   * field set.
    */
-  public List<BlockedCookieWithReason> getBlockedCookies() {
-    return blockedCookies;
+  public List<BlockedCookieWithReason> getAssociatedCookies() {
+    return associatedCookies;
   }
 
   /**
-   * A list of cookies which will not be sent with this request along with corresponding reasons for
-   * blocking.
+   * A list of cookies potentially associated to the requested URL. This includes both cookies sent
+   * with the request and the ones not sent; the latter are distinguished by having blockedReason
+   * field set.
    */
-  public void setBlockedCookies(List<BlockedCookieWithReason> blockedCookies) {
-    this.blockedCookies = blockedCookies;
+  public void setAssociatedCookies(List<BlockedCookieWithReason> associatedCookies) {
+    this.associatedCookies = associatedCookies;
   }
 
   /** Raw request headers as they will be sent over the wire. */

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/page/DownloadProgress.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/page/DownloadProgress.java
@@ -1,0 +1,76 @@
+package com.github.kklisura.cdt.protocol.events.page;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
+
+/** Fired when download makes progress. Last call has |done| == true. */
+@Experimental
+public class DownloadProgress {
+
+  private String guid;
+
+  private Double totalBytes;
+
+  private Double receivedBytes;
+
+  private DownloadProgressState state;
+
+  /** Global unique identifier of the download. */
+  public String getGuid() {
+    return guid;
+  }
+
+  /** Global unique identifier of the download. */
+  public void setGuid(String guid) {
+    this.guid = guid;
+  }
+
+  /** Total expected bytes to download. */
+  public Double getTotalBytes() {
+    return totalBytes;
+  }
+
+  /** Total expected bytes to download. */
+  public void setTotalBytes(Double totalBytes) {
+    this.totalBytes = totalBytes;
+  }
+
+  /** Total bytes received. */
+  public Double getReceivedBytes() {
+    return receivedBytes;
+  }
+
+  /** Total bytes received. */
+  public void setReceivedBytes(Double receivedBytes) {
+    this.receivedBytes = receivedBytes;
+  }
+
+  /** Download status. */
+  public DownloadProgressState getState() {
+    return state;
+  }
+
+  /** Download status. */
+  public void setState(DownloadProgressState state) {
+    this.state = state;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/page/DownloadProgressState.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/page/DownloadProgressState.java
@@ -1,0 +1,33 @@
+package com.github.kklisura.cdt.protocol.events.page;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Download status. */
+public enum DownloadProgressState {
+  @JsonProperty("inProgress")
+  IN_PROGRESS,
+  @JsonProperty("completed")
+  COMPLETED,
+  @JsonProperty("canceled")
+  CANCELED
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/page/DownloadWillBegin.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/page/DownloadWillBegin.java
@@ -28,7 +28,11 @@ public class DownloadWillBegin {
 
   private String frameId;
 
+  private String guid;
+
   private String url;
+
+  private String suggestedFilename;
 
   /** Id of the frame that caused download to begin. */
   public String getFrameId() {
@@ -40,6 +44,16 @@ public class DownloadWillBegin {
     this.frameId = frameId;
   }
 
+  /** Global unique identifier of the download. */
+  public String getGuid() {
+    return guid;
+  }
+
+  /** Global unique identifier of the download. */
+  public void setGuid(String guid) {
+    this.guid = guid;
+  }
+
   /** URL of the resource being downloaded. */
   public String getUrl() {
     return url;
@@ -48,5 +62,15 @@ public class DownloadWillBegin {
   /** URL of the resource being downloaded. */
   public void setUrl(String url) {
     this.url = url;
+  }
+
+  /** Suggested file name of the resource (the actual name of the file saved on disk may differ). */
+  public String getSuggestedFilename() {
+    return suggestedFilename;
+  }
+
+  /** Suggested file name of the resource (the actual name of the file saved on disk may differ). */
+  public void setSuggestedFilename(String suggestedFilename) {
+    this.suggestedFilename = suggestedFilename;
   }
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/page/FileChooserOpened.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/page/FileChooserOpened.java
@@ -20,15 +20,43 @@ package com.github.kklisura.cdt.protocol.events.page;
  * #L%
  */
 
+import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
+
 /** Emitted only when `page.interceptFileChooser` is enabled. */
 public class FileChooserOpened {
 
+  @Experimental private String frameId;
+
+  @Experimental private Integer backendNodeId;
+
   private FileChooserOpenedMode mode;
 
+  /** Id of the frame containing input node. */
+  public String getFrameId() {
+    return frameId;
+  }
+
+  /** Id of the frame containing input node. */
+  public void setFrameId(String frameId) {
+    this.frameId = frameId;
+  }
+
+  /** Input node id. */
+  public Integer getBackendNodeId() {
+    return backendNodeId;
+  }
+
+  /** Input node id. */
+  public void setBackendNodeId(Integer backendNodeId) {
+    this.backendNodeId = backendNodeId;
+  }
+
+  /** Input mode. */
   public FileChooserOpenedMode getMode() {
     return mode;
   }
 
+  /** Input mode. */
   public void setMode(FileChooserOpenedMode mode) {
     this.mode = mode;
   }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/page/FileChooserOpenedMode.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/page/FileChooserOpenedMode.java
@@ -22,6 +22,7 @@ package com.github.kklisura.cdt.protocol.events.page;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/** Input mode. */
 public enum FileChooserOpenedMode {
   @JsonProperty("selectSingle")
   SELECT_SINGLE,

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/page/FrameRequestedNavigation.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/page/FrameRequestedNavigation.java
@@ -21,6 +21,7 @@ package com.github.kklisura.cdt.protocol.events.page;
  */
 
 import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
+import com.github.kklisura.cdt.protocol.types.page.ClientNavigationDisposition;
 import com.github.kklisura.cdt.protocol.types.page.ClientNavigationReason;
 
 /**
@@ -35,6 +36,8 @@ public class FrameRequestedNavigation {
   private ClientNavigationReason reason;
 
   private String url;
+
+  private ClientNavigationDisposition disposition;
 
   /** Id of the frame that is being navigated. */
   public String getFrameId() {
@@ -64,5 +67,15 @@ public class FrameRequestedNavigation {
   /** The destination URL for the requested navigation. */
   public void setUrl(String url) {
     this.url = url;
+  }
+
+  /** The disposition for the navigation. */
+  public ClientNavigationDisposition getDisposition() {
+    return disposition;
+  }
+
+  /** The disposition for the navigation. */
+  public void setDisposition(ClientNavigationDisposition disposition) {
+    this.disposition = disposition;
   }
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/page/FrameScheduledNavigation.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/page/FrameScheduledNavigation.java
@@ -20,6 +20,8 @@ package com.github.kklisura.cdt.protocol.events.page;
  * #L%
  */
 
+import com.github.kklisura.cdt.protocol.types.page.ClientNavigationReason;
+
 /** Fired when frame schedules a potential navigation. */
 @Deprecated
 public class FrameScheduledNavigation {
@@ -28,7 +30,7 @@ public class FrameScheduledNavigation {
 
   private Double delay;
 
-  private FrameScheduledNavigationReason reason;
+  private ClientNavigationReason reason;
 
   private String url;
 
@@ -59,12 +61,12 @@ public class FrameScheduledNavigation {
   }
 
   /** The reason for the navigation. */
-  public FrameScheduledNavigationReason getReason() {
+  public ClientNavigationReason getReason() {
     return reason;
   }
 
   /** The reason for the navigation. */
-  public void setReason(FrameScheduledNavigationReason reason) {
+  public void setReason(ClientNavigationReason reason) {
     this.reason = reason;
   }
 

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/profiler/PreciseCoverageDeltaUpdate.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/profiler/PreciseCoverageDeltaUpdate.java
@@ -1,0 +1,75 @@
+package com.github.kklisura.cdt.protocol.events.profiler;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
+import com.github.kklisura.cdt.protocol.types.profiler.ScriptCoverage;
+import java.util.List;
+
+/**
+ * Reports coverage delta since the last poll (either from an event like this, or from
+ * `takePreciseCoverage` for the current isolate. May only be sent if precise code coverage has been
+ * started. This event can be trigged by the embedder to, for example, trigger collection of
+ * coverage data immediatelly at a certain point in time.
+ */
+@Experimental
+public class PreciseCoverageDeltaUpdate {
+
+  private Double timestamp;
+
+  private String occassion;
+
+  private List<ScriptCoverage> result;
+
+  /**
+   * Monotonically increasing time (in seconds) when the coverage update was taken in the backend.
+   */
+  public Double getTimestamp() {
+    return timestamp;
+  }
+
+  /**
+   * Monotonically increasing time (in seconds) when the coverage update was taken in the backend.
+   */
+  public void setTimestamp(Double timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  /** Identifier for distinguishing coverage events. */
+  public String getOccassion() {
+    return occassion;
+  }
+
+  /** Identifier for distinguishing coverage events. */
+  public void setOccassion(String occassion) {
+    this.occassion = occassion;
+  }
+
+  /** Coverage data for the current isolate. */
+  public List<ScriptCoverage> getResult() {
+    return result;
+  }
+
+  /** Coverage data for the current isolate. */
+  public void setResult(List<ScriptCoverage> result) {
+    this.result = result;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/security/VisibleSecurityStateChanged.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/events/security/VisibleSecurityStateChanged.java
@@ -1,0 +1,41 @@
+package com.github.kklisura.cdt.protocol.events.security;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
+import com.github.kklisura.cdt.protocol.types.security.VisibleSecurityState;
+
+/** The security state of the page changed. */
+@Experimental
+public class VisibleSecurityStateChanged {
+
+  private VisibleSecurityState visibleSecurityState;
+
+  /** Security state information about the page. */
+  public VisibleSecurityState getVisibleSecurityState() {
+    return visibleSecurityState;
+  }
+
+  /** Security state information about the page. */
+  public void setVisibleSecurityState(VisibleSecurityState visibleSecurityState) {
+    this.visibleSecurityState = visibleSecurityState;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/support/annotations/EventName.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/support/annotations/EventName.java
@@ -4,7 +4,7 @@ package com.github.kklisura.cdt.protocol.support.annotations;
  * #%L
  * cdt-java-client
  * %%
- * Copyright (C) 2018 Kenan Klisura
+ * Copyright (C) 2018 - 2019 Kenan Klisura
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/support/annotations/Experimental.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/support/annotations/Experimental.java
@@ -4,7 +4,7 @@ package com.github.kklisura.cdt.protocol.support.annotations;
  * #%L
  * cdt-java-client
  * %%
- * Copyright (C) 2018 Kenan Klisura
+ * Copyright (C) 2018 - 2019 Kenan Klisura
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/support/annotations/Optional.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/support/annotations/Optional.java
@@ -4,7 +4,7 @@ package com.github.kklisura.cdt.protocol.support.annotations;
  * #%L
  * cdt-java-client
  * %%
- * Copyright (C) 2018 Kenan Klisura
+ * Copyright (C) 2018 - 2019 Kenan Klisura
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/support/annotations/ParamName.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/support/annotations/ParamName.java
@@ -4,7 +4,7 @@ package com.github.kklisura.cdt.protocol.support.annotations;
  * #%L
  * cdt-java-client
  * %%
- * Copyright (C) 2018 Kenan Klisura
+ * Copyright (C) 2018 - 2019 Kenan Klisura
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/support/annotations/Returns.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/support/annotations/Returns.java
@@ -4,7 +4,7 @@ package com.github.kklisura.cdt.protocol.support.annotations;
  * #%L
  * cdt-java-client
  * %%
- * Copyright (C) 2018 Kenan Klisura
+ * Copyright (C) 2018 - 2019 Kenan Klisura
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/support/types/EventHandler.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/support/types/EventHandler.java
@@ -4,7 +4,7 @@ package com.github.kklisura.cdt.protocol.support.types;
  * #%L
  * cdt-java-client
  * %%
- * Copyright (C) 2018 Kenan Klisura
+ * Copyright (C) 2018 - 2019 Kenan Klisura
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/support/types/EventListener.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/support/types/EventListener.java
@@ -4,7 +4,7 @@ package com.github.kklisura.cdt.protocol.support.types;
  * #%L
  * cdt-java-client
  * %%
- * Copyright (C) 2018 Kenan Klisura
+ * Copyright (C) 2018 - 2019 Kenan Klisura
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/AffectedCookie.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/AffectedCookie.java
@@ -1,0 +1,57 @@
+package com.github.kklisura.cdt.protocol.types.audits;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/** Information about a cookie that is affected by an inspector issue. */
+public class AffectedCookie {
+
+  private String name;
+
+  private String path;
+
+  private String domain;
+
+  /** The following three properties uniquely identify a cookie */
+  public String getName() {
+    return name;
+  }
+
+  /** The following three properties uniquely identify a cookie */
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  public String getDomain() {
+    return domain;
+  }
+
+  public void setDomain(String domain) {
+    this.domain = domain;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/AffectedFrame.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/AffectedFrame.java
@@ -1,4 +1,4 @@
-package com.github.kklisura.cdt.protocol.types.input;
+package com.github.kklisura.cdt.protocol.types.audits;
 
 /*-
  * #%L
@@ -20,20 +20,16 @@ package com.github.kklisura.cdt.protocol.types.input;
  * #L%
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+/** Information about the frame affected by an inspector issue. */
+public class AffectedFrame {
 
-/** Mouse button (default: "none"). */
-public enum DispatchMouseEventButton {
-  @JsonProperty("none")
-  NONE,
-  @JsonProperty("left")
-  LEFT,
-  @JsonProperty("middle")
-  MIDDLE,
-  @JsonProperty("right")
-  RIGHT,
-  @JsonProperty("back")
-  BACK,
-  @JsonProperty("forward")
-  FORWARD
+  private String frameId;
+
+  public String getFrameId() {
+    return frameId;
+  }
+
+  public void setFrameId(String frameId) {
+    this.frameId = frameId;
+  }
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/AffectedRequest.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/AffectedRequest.java
@@ -1,0 +1,49 @@
+package com.github.kklisura.cdt.protocol.types.audits;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.support.annotations.Optional;
+
+/** Information about a request that is affected by an inspector issue. */
+public class AffectedRequest {
+
+  private String requestId;
+
+  @Optional private String url;
+
+  /** The unique request id. */
+  public String getRequestId() {
+    return requestId;
+  }
+
+  /** The unique request id. */
+  public void setRequestId(String requestId) {
+    this.requestId = requestId;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/BlockedByResponseIssueDetails.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/BlockedByResponseIssueDetails.java
@@ -1,0 +1,60 @@
+package com.github.kklisura.cdt.protocol.types.audits;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.support.annotations.Optional;
+
+/**
+ * Details for a request that has been blocked with the BLOCKED_BY_RESPONSE code. Currently only
+ * used for COEP/COOP, but may be extended to include some CSP errors in the future.
+ */
+public class BlockedByResponseIssueDetails {
+
+  private AffectedRequest request;
+
+  @Optional private AffectedFrame frame;
+
+  private BlockedByResponseReason reason;
+
+  public AffectedRequest getRequest() {
+    return request;
+  }
+
+  public void setRequest(AffectedRequest request) {
+    this.request = request;
+  }
+
+  public AffectedFrame getFrame() {
+    return frame;
+  }
+
+  public void setFrame(AffectedFrame frame) {
+    this.frame = frame;
+  }
+
+  public BlockedByResponseReason getReason() {
+    return reason;
+  }
+
+  public void setReason(BlockedByResponseReason reason) {
+    this.reason = reason;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/BlockedByResponseReason.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/BlockedByResponseReason.java
@@ -1,0 +1,40 @@
+package com.github.kklisura.cdt.protocol.types.audits;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Enum indicating the reason a response has been blocked. These reasons are refinements of the net
+ * error BLOCKED_BY_RESPONSE.
+ */
+public enum BlockedByResponseReason {
+  @JsonProperty("CoepFrameResourceNeedsCoepHeader")
+  COEP_FRAME_RESOURCE_NEEDS_COEP_HEADER,
+  @JsonProperty("CoopSandboxedIFrameCannotNavigateToCoopPage")
+  COOP_SANDBOXED_I_FRAME_CANNOT_NAVIGATE_TO_COOP_PAGE,
+  @JsonProperty("CorpNotSameOrigin")
+  CORP_NOT_SAME_ORIGIN,
+  @JsonProperty("CorpNotSameOriginAfterDefaultedToSameOriginByCoep")
+  CORP_NOT_SAME_ORIGIN_AFTER_DEFAULTED_TO_SAME_ORIGIN_BY_COEP,
+  @JsonProperty("CorpNotSameSite")
+  CORP_NOT_SAME_SITE
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/InspectorIssue.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/InspectorIssue.java
@@ -1,0 +1,45 @@
+package com.github.kklisura.cdt.protocol.types.audits;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/** An inspector issue reported from the back-end. */
+public class InspectorIssue {
+
+  private InspectorIssueCode code;
+
+  private InspectorIssueDetails details;
+
+  public InspectorIssueCode getCode() {
+    return code;
+  }
+
+  public void setCode(InspectorIssueCode code) {
+    this.code = code;
+  }
+
+  public InspectorIssueDetails getDetails() {
+    return details;
+  }
+
+  public void setDetails(InspectorIssueDetails details) {
+    this.details = details;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/InspectorIssueCode.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/InspectorIssueCode.java
@@ -1,4 +1,4 @@
-package com.github.kklisura.cdt.protocol.types.input;
+package com.github.kklisura.cdt.protocol.types.audits;
 
 /*-
  * #%L
@@ -22,14 +22,15 @@ package com.github.kklisura.cdt.protocol.types.input;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/** Mouse button. */
-public enum EmulateTouchFromMouseEventButton {
-  @JsonProperty("none")
-  NONE,
-  @JsonProperty("left")
-  LEFT,
-  @JsonProperty("middle")
-  MIDDLE,
-  @JsonProperty("right")
-  RIGHT
+/**
+ * A unique identifier for the type of issue. Each type may use one of the optional fields in
+ * InspectorIssueDetails to convey more specific information about the kind of issue.
+ */
+public enum InspectorIssueCode {
+  @JsonProperty("SameSiteCookieIssue")
+  SAME_SITE_COOKIE_ISSUE,
+  @JsonProperty("MixedContentIssue")
+  MIXED_CONTENT_ISSUE,
+  @JsonProperty("BlockedByResponseIssue")
+  BLOCKED_BY_RESPONSE_ISSUE
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/InspectorIssueDetails.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/InspectorIssueDetails.java
@@ -1,0 +1,61 @@
+package com.github.kklisura.cdt.protocol.types.audits;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.support.annotations.Optional;
+
+/**
+ * This struct holds a list of optional fields with additional information specific to the kind of
+ * issue. When adding a new issue code, please also add a new optional field to this type.
+ */
+public class InspectorIssueDetails {
+
+  @Optional private SameSiteCookieIssueDetails sameSiteCookieIssueDetails;
+
+  @Optional private MixedContentIssueDetails mixedContentIssueDetails;
+
+  @Optional private BlockedByResponseIssueDetails blockedByResponseIssueDetails;
+
+  public SameSiteCookieIssueDetails getSameSiteCookieIssueDetails() {
+    return sameSiteCookieIssueDetails;
+  }
+
+  public void setSameSiteCookieIssueDetails(SameSiteCookieIssueDetails sameSiteCookieIssueDetails) {
+    this.sameSiteCookieIssueDetails = sameSiteCookieIssueDetails;
+  }
+
+  public MixedContentIssueDetails getMixedContentIssueDetails() {
+    return mixedContentIssueDetails;
+  }
+
+  public void setMixedContentIssueDetails(MixedContentIssueDetails mixedContentIssueDetails) {
+    this.mixedContentIssueDetails = mixedContentIssueDetails;
+  }
+
+  public BlockedByResponseIssueDetails getBlockedByResponseIssueDetails() {
+    return blockedByResponseIssueDetails;
+  }
+
+  public void setBlockedByResponseIssueDetails(
+      BlockedByResponseIssueDetails blockedByResponseIssueDetails) {
+    this.blockedByResponseIssueDetails = blockedByResponseIssueDetails;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/MixedContentIssueDetails.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/MixedContentIssueDetails.java
@@ -1,0 +1,106 @@
+package com.github.kklisura.cdt.protocol.types.audits;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.support.annotations.Optional;
+
+public class MixedContentIssueDetails {
+
+  @Optional private MixedContentResourceType resourceType;
+
+  private MixedContentResolutionStatus resolutionStatus;
+
+  private String insecureURL;
+
+  private String mainResourceURL;
+
+  @Optional private AffectedRequest request;
+
+  @Optional private AffectedFrame frame;
+
+  /**
+   * The type of resource causing the mixed content issue (css, js, iframe, form,...). Marked as
+   * optional because it is mapped to from blink::mojom::RequestContextType, which will be replaced
+   * by network::mojom::RequestDestination
+   */
+  public MixedContentResourceType getResourceType() {
+    return resourceType;
+  }
+
+  /**
+   * The type of resource causing the mixed content issue (css, js, iframe, form,...). Marked as
+   * optional because it is mapped to from blink::mojom::RequestContextType, which will be replaced
+   * by network::mojom::RequestDestination
+   */
+  public void setResourceType(MixedContentResourceType resourceType) {
+    this.resourceType = resourceType;
+  }
+
+  /** The way the mixed content issue is being resolved. */
+  public MixedContentResolutionStatus getResolutionStatus() {
+    return resolutionStatus;
+  }
+
+  /** The way the mixed content issue is being resolved. */
+  public void setResolutionStatus(MixedContentResolutionStatus resolutionStatus) {
+    this.resolutionStatus = resolutionStatus;
+  }
+
+  /** The unsafe http url causing the mixed content issue. */
+  public String getInsecureURL() {
+    return insecureURL;
+  }
+
+  /** The unsafe http url causing the mixed content issue. */
+  public void setInsecureURL(String insecureURL) {
+    this.insecureURL = insecureURL;
+  }
+
+  /** The url responsible for the call to an unsafe url. */
+  public String getMainResourceURL() {
+    return mainResourceURL;
+  }
+
+  /** The url responsible for the call to an unsafe url. */
+  public void setMainResourceURL(String mainResourceURL) {
+    this.mainResourceURL = mainResourceURL;
+  }
+
+  /** The mixed content request. Does not always exist (e.g. for unsafe form submission urls). */
+  public AffectedRequest getRequest() {
+    return request;
+  }
+
+  /** The mixed content request. Does not always exist (e.g. for unsafe form submission urls). */
+  public void setRequest(AffectedRequest request) {
+    this.request = request;
+  }
+
+  /** Optional because not every mixed content issue is necessarily linked to a frame. */
+  public AffectedFrame getFrame() {
+    return frame;
+  }
+
+  /** Optional because not every mixed content issue is necessarily linked to a frame. */
+  public void setFrame(AffectedFrame frame) {
+    this.frame = frame;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/MixedContentResolutionStatus.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/MixedContentResolutionStatus.java
@@ -1,0 +1,32 @@
+package com.github.kklisura.cdt.protocol.types.audits;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum MixedContentResolutionStatus {
+  @JsonProperty("MixedContentBlocked")
+  MIXED_CONTENT_BLOCKED,
+  @JsonProperty("MixedContentAutomaticallyUpgraded")
+  MIXED_CONTENT_AUTOMATICALLY_UPGRADED,
+  @JsonProperty("MixedContentWarning")
+  MIXED_CONTENT_WARNING
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/MixedContentResourceType.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/MixedContentResourceType.java
@@ -1,0 +1,78 @@
+package com.github.kklisura.cdt.protocol.types.audits;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum MixedContentResourceType {
+  @JsonProperty("Audio")
+  AUDIO,
+  @JsonProperty("Beacon")
+  BEACON,
+  @JsonProperty("CSPReport")
+  CSP_REPORT,
+  @JsonProperty("Download")
+  DOWNLOAD,
+  @JsonProperty("EventSource")
+  EVENT_SOURCE,
+  @JsonProperty("Favicon")
+  FAVICON,
+  @JsonProperty("Font")
+  FONT,
+  @JsonProperty("Form")
+  FORM,
+  @JsonProperty("Frame")
+  FRAME,
+  @JsonProperty("Image")
+  IMAGE,
+  @JsonProperty("Import")
+  IMPORT,
+  @JsonProperty("Manifest")
+  MANIFEST,
+  @JsonProperty("Ping")
+  PING,
+  @JsonProperty("PluginData")
+  PLUGIN_DATA,
+  @JsonProperty("PluginResource")
+  PLUGIN_RESOURCE,
+  @JsonProperty("Prefetch")
+  PREFETCH,
+  @JsonProperty("Resource")
+  RESOURCE,
+  @JsonProperty("Script")
+  SCRIPT,
+  @JsonProperty("ServiceWorker")
+  SERVICE_WORKER,
+  @JsonProperty("SharedWorker")
+  SHARED_WORKER,
+  @JsonProperty("Stylesheet")
+  STYLESHEET,
+  @JsonProperty("Track")
+  TRACK,
+  @JsonProperty("Video")
+  VIDEO,
+  @JsonProperty("Worker")
+  WORKER,
+  @JsonProperty("XMLHttpRequest")
+  XML_HTTP_REQUEST,
+  @JsonProperty("XSLT")
+  XSLT
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/SameSiteCookieExclusionReason.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/SameSiteCookieExclusionReason.java
@@ -1,4 +1,4 @@
-package com.github.kklisura.cdt.protocol.types.page;
+package com.github.kklisura.cdt.protocol.types.audits;
 
 /*-
  * #%L
@@ -22,11 +22,9 @@ package com.github.kklisura.cdt.protocol.types.page;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public enum HandleFileChooserAction {
-  @JsonProperty("accept")
-  ACCEPT,
-  @JsonProperty("cancel")
-  CANCEL,
-  @JsonProperty("fallback")
-  FALLBACK
+public enum SameSiteCookieExclusionReason {
+  @JsonProperty("ExcludeSameSiteUnspecifiedTreatedAsLax")
+  EXCLUDE_SAME_SITE_UNSPECIFIED_TREATED_AS_LAX,
+  @JsonProperty("ExcludeSameSiteNoneInsecure")
+  EXCLUDE_SAME_SITE_NONE_INSECURE
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/SameSiteCookieIssueDetails.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/SameSiteCookieIssueDetails.java
@@ -1,0 +1,110 @@
+package com.github.kklisura.cdt.protocol.types.audits;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.support.annotations.Optional;
+import java.util.List;
+
+/**
+ * This information is currently necessary, as the front-end has a difficult time finding a specific
+ * cookie. With this, we can convey specific error information without the cookie.
+ */
+public class SameSiteCookieIssueDetails {
+
+  private AffectedCookie cookie;
+
+  private List<SameSiteCookieWarningReason> cookieWarningReasons;
+
+  private List<SameSiteCookieExclusionReason> cookieExclusionReasons;
+
+  private SameSiteCookieOperation operation;
+
+  @Optional private String siteForCookies;
+
+  @Optional private String cookieUrl;
+
+  @Optional private AffectedRequest request;
+
+  public AffectedCookie getCookie() {
+    return cookie;
+  }
+
+  public void setCookie(AffectedCookie cookie) {
+    this.cookie = cookie;
+  }
+
+  public List<SameSiteCookieWarningReason> getCookieWarningReasons() {
+    return cookieWarningReasons;
+  }
+
+  public void setCookieWarningReasons(List<SameSiteCookieWarningReason> cookieWarningReasons) {
+    this.cookieWarningReasons = cookieWarningReasons;
+  }
+
+  public List<SameSiteCookieExclusionReason> getCookieExclusionReasons() {
+    return cookieExclusionReasons;
+  }
+
+  public void setCookieExclusionReasons(
+      List<SameSiteCookieExclusionReason> cookieExclusionReasons) {
+    this.cookieExclusionReasons = cookieExclusionReasons;
+  }
+
+  /**
+   * Optionally identifies the site-for-cookies and the cookie url, which may be used by the
+   * front-end as additional context.
+   */
+  public SameSiteCookieOperation getOperation() {
+    return operation;
+  }
+
+  /**
+   * Optionally identifies the site-for-cookies and the cookie url, which may be used by the
+   * front-end as additional context.
+   */
+  public void setOperation(SameSiteCookieOperation operation) {
+    this.operation = operation;
+  }
+
+  public String getSiteForCookies() {
+    return siteForCookies;
+  }
+
+  public void setSiteForCookies(String siteForCookies) {
+    this.siteForCookies = siteForCookies;
+  }
+
+  public String getCookieUrl() {
+    return cookieUrl;
+  }
+
+  public void setCookieUrl(String cookieUrl) {
+    this.cookieUrl = cookieUrl;
+  }
+
+  public AffectedRequest getRequest() {
+    return request;
+  }
+
+  public void setRequest(AffectedRequest request) {
+    this.request = request;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/SameSiteCookieOperation.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/SameSiteCookieOperation.java
@@ -1,0 +1,30 @@
+package com.github.kklisura.cdt.protocol.types.audits;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum SameSiteCookieOperation {
+  @JsonProperty("SetCookie")
+  SET_COOKIE,
+  @JsonProperty("ReadCookie")
+  READ_COOKIE
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/SameSiteCookieWarningReason.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/audits/SameSiteCookieWarningReason.java
@@ -1,0 +1,42 @@
+package com.github.kklisura.cdt.protocol.types.audits;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum SameSiteCookieWarningReason {
+  @JsonProperty("WarnSameSiteUnspecifiedCrossSiteContext")
+  WARN_SAME_SITE_UNSPECIFIED_CROSS_SITE_CONTEXT,
+  @JsonProperty("WarnSameSiteNoneInsecure")
+  WARN_SAME_SITE_NONE_INSECURE,
+  @JsonProperty("WarnSameSiteUnspecifiedLaxAllowUnsafe")
+  WARN_SAME_SITE_UNSPECIFIED_LAX_ALLOW_UNSAFE,
+  @JsonProperty("WarnSameSiteStrictLaxDowngradeStrict")
+  WARN_SAME_SITE_STRICT_LAX_DOWNGRADE_STRICT,
+  @JsonProperty("WarnSameSiteStrictCrossDowngradeStrict")
+  WARN_SAME_SITE_STRICT_CROSS_DOWNGRADE_STRICT,
+  @JsonProperty("WarnSameSiteStrictCrossDowngradeLax")
+  WARN_SAME_SITE_STRICT_CROSS_DOWNGRADE_LAX,
+  @JsonProperty("WarnSameSiteLaxCrossDowngradeStrict")
+  WARN_SAME_SITE_LAX_CROSS_DOWNGRADE_STRICT,
+  @JsonProperty("WarnSameSiteLaxCrossDowngradeLax")
+  WARN_SAME_SITE_LAX_CROSS_DOWNGRADE_LAX
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/browser/PermissionDescriptor.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/browser/PermissionDescriptor.java
@@ -38,6 +38,8 @@ public class PermissionDescriptor {
 
   @Optional private String type;
 
+  @Optional private Boolean allowWithoutSanitization;
+
   /**
    * Name of permission. See
    * https://cs.chromium.org/chromium/src/third_party/blink/renderer/modules/permissions/permission_descriptor.idl
@@ -90,5 +92,15 @@ public class PermissionDescriptor {
   /** For "wake-lock" permission, must specify type as either "screen" or "system". */
   public void setType(String type) {
     this.type = type;
+  }
+
+  /** For "clipboard" permission, may specify allowWithoutSanitization. */
+  public Boolean getAllowWithoutSanitization() {
+    return allowWithoutSanitization;
+  }
+
+  /** For "clipboard" permission, may specify allowWithoutSanitization. */
+  public void setAllowWithoutSanitization(Boolean allowWithoutSanitization) {
+    this.allowWithoutSanitization = allowWithoutSanitization;
   }
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/browser/PermissionType.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/browser/PermissionType.java
@@ -31,10 +31,10 @@ public enum PermissionType {
   BACKGROUND_SYNC,
   @JsonProperty("backgroundFetch")
   BACKGROUND_FETCH,
-  @JsonProperty("clipboardRead")
-  CLIPBOARD_READ,
-  @JsonProperty("clipboardWrite")
-  CLIPBOARD_WRITE,
+  @JsonProperty("clipboardReadWrite")
+  CLIPBOARD_READ_WRITE,
+  @JsonProperty("clipboardSanitizedWrite")
+  CLIPBOARD_SANITIZED_WRITE,
   @JsonProperty("durableStorage")
   DURABLE_STORAGE,
   @JsonProperty("flash")
@@ -45,6 +45,8 @@ public enum PermissionType {
   MIDI,
   @JsonProperty("midiSysex")
   MIDI_SYSEX,
+  @JsonProperty("nfc")
+  NFC,
   @JsonProperty("notifications")
   NOTIFICATIONS,
   @JsonProperty("paymentHandler")

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/browser/SetDownloadBehaviorBehavior.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/browser/SetDownloadBehaviorBehavior.java
@@ -1,0 +1,39 @@
+package com.github.kklisura.cdt.protocol.types.browser;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Whether to allow all or deny all download requests, or use default Chrome behavior if available
+ * (otherwise deny). |allowAndName| allows download and names files according to their dowmload
+ * guids.
+ */
+public enum SetDownloadBehaviorBehavior {
+  @JsonProperty("deny")
+  DENY,
+  @JsonProperty("allow")
+  ALLOW,
+  @JsonProperty("allowAndName")
+  ALLOW_AND_NAME,
+  @JsonProperty("default")
+  DEFAULT
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/css/CSSStyleSheetHeader.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/css/CSSStyleSheetHeader.java
@@ -51,6 +51,10 @@ public class CSSStyleSheetHeader {
 
   private Double length;
 
+  private Double endLine;
+
+  private Double endColumn;
+
   /** The stylesheet identifier. */
   public String getStyleSheetId() {
     return styleSheetId;
@@ -185,5 +189,25 @@ public class CSSStyleSheetHeader {
   /** Size of the content (in characters). */
   public void setLength(Double length) {
     this.length = length;
+  }
+
+  /** Line offset of the end of the stylesheet within the resource (zero based). */
+  public Double getEndLine() {
+    return endLine;
+  }
+
+  /** Line offset of the end of the stylesheet within the resource (zero based). */
+  public void setEndLine(Double endLine) {
+    this.endLine = endLine;
+  }
+
+  /** Column offset of the end of the stylesheet within the resource (zero based). */
+  public Double getEndColumn() {
+    return endColumn;
+  }
+
+  /** Column offset of the end of the stylesheet within the resource (zero based). */
+  public void setEndColumn(Double endColumn) {
+    this.endColumn = endColumn;
   }
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/css/TakeCoverageDelta.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/css/TakeCoverageDelta.java
@@ -1,0 +1,48 @@
+package com.github.kklisura.cdt.protocol.types.css;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.List;
+
+public class TakeCoverageDelta {
+
+  private List<RuleUsage> coverage;
+
+  private Double timestamp;
+
+  public List<RuleUsage> getCoverage() {
+    return coverage;
+  }
+
+  public void setCoverage(List<RuleUsage> coverage) {
+    this.coverage = coverage;
+  }
+
+  /** Monotonically increasing time, in seconds. */
+  public Double getTimestamp() {
+    return timestamp;
+  }
+
+  /** Monotonically increasing time, in seconds. */
+  public void setTimestamp(Double timestamp) {
+    this.timestamp = timestamp;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/debugger/DebugSymbols.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/debugger/DebugSymbols.java
@@ -1,0 +1,51 @@
+package com.github.kklisura.cdt.protocol.types.debugger;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.support.annotations.Optional;
+
+/** Debug symbols available for a wasm script. */
+public class DebugSymbols {
+
+  private DebugSymbolsType type;
+
+  @Optional private String externalURL;
+
+  /** Type of the debug symbols. */
+  public DebugSymbolsType getType() {
+    return type;
+  }
+
+  /** Type of the debug symbols. */
+  public void setType(DebugSymbolsType type) {
+    this.type = type;
+  }
+
+  /** URL of the external symbol source. */
+  public String getExternalURL() {
+    return externalURL;
+  }
+
+  /** URL of the external symbol source. */
+  public void setExternalURL(String externalURL) {
+    this.externalURL = externalURL;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/debugger/DebugSymbolsType.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/debugger/DebugSymbolsType.java
@@ -1,0 +1,35 @@
+package com.github.kklisura.cdt.protocol.types.debugger;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Type of the debug symbols. */
+public enum DebugSymbolsType {
+  @JsonProperty("None")
+  NONE,
+  @JsonProperty("SourceMap")
+  SOURCE_MAP,
+  @JsonProperty("EmbeddedDWARF")
+  EMBEDDED_DWARF,
+  @JsonProperty("ExternalDWARF")
+  EXTERNAL_DWARF
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/debugger/ExecuteWasmEvaluator.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/debugger/ExecuteWasmEvaluator.java
@@ -1,0 +1,52 @@
+package com.github.kklisura.cdt.protocol.types.debugger;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.support.annotations.Optional;
+import com.github.kklisura.cdt.protocol.types.runtime.ExceptionDetails;
+import com.github.kklisura.cdt.protocol.types.runtime.RemoteObject;
+
+public class ExecuteWasmEvaluator {
+
+  private RemoteObject result;
+
+  @Optional private ExceptionDetails exceptionDetails;
+
+  /** Object wrapper for the evaluation result. */
+  public RemoteObject getResult() {
+    return result;
+  }
+
+  /** Object wrapper for the evaluation result. */
+  public void setResult(RemoteObject result) {
+    this.result = result;
+  }
+
+  /** Exception details. */
+  public ExceptionDetails getExceptionDetails() {
+    return exceptionDetails;
+  }
+
+  /** Exception details. */
+  public void setExceptionDetails(ExceptionDetails exceptionDetails) {
+    this.exceptionDetails = exceptionDetails;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/debugger/ScopeType.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/debugger/ScopeType.java
@@ -41,5 +41,7 @@ public enum ScopeType {
   @JsonProperty("eval")
   EVAL,
   @JsonProperty("module")
-  MODULE
+  MODULE,
+  @JsonProperty("wasm-expression-stack")
+  WASM_EXPRESSION_STACK
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/debugger/ScriptLanguage.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/debugger/ScriptLanguage.java
@@ -1,0 +1,31 @@
+package com.github.kklisura.cdt.protocol.types.debugger;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Enum of possible script languages. */
+public enum ScriptLanguage {
+  @JsonProperty("JavaScript")
+  JAVA_SCRIPT,
+  @JsonProperty("WebAssembly")
+  WEB_ASSEMBLY
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/debugger/ScriptSource.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/debugger/ScriptSource.java
@@ -1,0 +1,50 @@
+package com.github.kklisura.cdt.protocol.types.debugger;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.support.annotations.Optional;
+
+public class ScriptSource {
+
+  private String scriptSource;
+
+  @Optional private String bytecode;
+
+  /** Script source (empty in case of Wasm bytecode). */
+  public String getScriptSource() {
+    return scriptSource;
+  }
+
+  /** Script source (empty in case of Wasm bytecode). */
+  public void setScriptSource(String scriptSource) {
+    this.scriptSource = scriptSource;
+  }
+
+  /** Wasm bytecode. */
+  public String getBytecode() {
+    return bytecode;
+  }
+
+  /** Wasm bytecode. */
+  public void setBytecode(String bytecode) {
+    this.bytecode = bytecode;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/dom/NodeForLocation.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/dom/NodeForLocation.java
@@ -26,6 +26,8 @@ public class NodeForLocation {
 
   private Integer backendNodeId;
 
+  private String frameId;
+
   @Optional private Integer nodeId;
 
   /** Resulting node. */
@@ -36,6 +38,16 @@ public class NodeForLocation {
   /** Resulting node. */
   public void setBackendNodeId(Integer backendNodeId) {
     this.backendNodeId = backendNodeId;
+  }
+
+  /** Frame this node belongs to. */
+  public String getFrameId() {
+    return frameId;
+  }
+
+  /** Frame this node belongs to. */
+  public void setFrameId(String frameId) {
+    this.frameId = frameId;
   }
 
   /** Id of the node at given coordinates, only when enabled and requested document. */

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/dom/PseudoType.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/dom/PseudoType.java
@@ -32,6 +32,8 @@ public enum PseudoType {
   BEFORE,
   @JsonProperty("after")
   AFTER,
+  @JsonProperty("marker")
+  MARKER,
   @JsonProperty("backdrop")
   BACKDROP,
   @JsonProperty("selection")

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/domsnapshot/DocumentSnapshot.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/domsnapshot/DocumentSnapshot.java
@@ -27,6 +27,8 @@ public class DocumentSnapshot {
 
   private Integer documentURL;
 
+  private Integer title;
+
   private Integer baseURL;
 
   private Integer contentLanguage;
@@ -49,6 +51,10 @@ public class DocumentSnapshot {
 
   @Optional private Double scrollOffsetY;
 
+  @Optional private Double contentWidth;
+
+  @Optional private Double contentHeight;
+
   /** Document URL that `Document` or `FrameOwner` node points to. */
   public Integer getDocumentURL() {
     return documentURL;
@@ -57,6 +63,16 @@ public class DocumentSnapshot {
   /** Document URL that `Document` or `FrameOwner` node points to. */
   public void setDocumentURL(Integer documentURL) {
     this.documentURL = documentURL;
+  }
+
+  /** Document title. */
+  public Integer getTitle() {
+    return title;
+  }
+
+  /** Document title. */
+  public void setTitle(Integer title) {
+    this.title = title;
   }
 
   /** Base URL that `Document` or `FrameOwner` node uses for URL completion. */
@@ -167,5 +183,25 @@ public class DocumentSnapshot {
   /** Vertical scroll offset. */
   public void setScrollOffsetY(Double scrollOffsetY) {
     this.scrollOffsetY = scrollOffsetY;
+  }
+
+  /** Document content width. */
+  public Double getContentWidth() {
+    return contentWidth;
+  }
+
+  /** Document content width. */
+  public void setContentWidth(Double contentWidth) {
+    this.contentWidth = contentWidth;
+  }
+
+  /** Document content height. */
+  public Double getContentHeight() {
+    return contentHeight;
+  }
+
+  /** Document content height. */
+  public void setContentHeight(Double contentHeight) {
+    this.contentHeight = contentHeight;
   }
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/emulation/MediaFeature.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/emulation/MediaFeature.java
@@ -1,0 +1,44 @@
+package com.github.kklisura.cdt.protocol.types.emulation;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+public class MediaFeature {
+
+  private String name;
+
+  private String value;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/emulation/SetEmulatedVisionDeficiencyType.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/emulation/SetEmulatedVisionDeficiencyType.java
@@ -1,0 +1,39 @@
+package com.github.kklisura.cdt.protocol.types.emulation;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Vision deficiency to emulate. */
+public enum SetEmulatedVisionDeficiencyType {
+  @JsonProperty("none")
+  NONE,
+  @JsonProperty("achromatopsia")
+  ACHROMATOPSIA,
+  @JsonProperty("blurredVision")
+  BLURRED_VISION,
+  @JsonProperty("deuteranopia")
+  DEUTERANOPIA,
+  @JsonProperty("protanopia")
+  PROTANOPIA,
+  @JsonProperty("tritanopia")
+  TRITANOPIA
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/emulation/UserAgentBrandVersion.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/emulation/UserAgentBrandVersion.java
@@ -1,0 +1,48 @@
+package com.github.kklisura.cdt.protocol.types.emulation;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
+
+/** Used to specify User Agent Cient Hints to emulate. See https://wicg.github.io/ua-client-hints */
+@Experimental
+public class UserAgentBrandVersion {
+
+  private String brand;
+
+  private String version;
+
+  public String getBrand() {
+    return brand;
+  }
+
+  public void setBrand(String brand) {
+    this.brand = brand;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/emulation/UserAgentMetadata.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/emulation/UserAgentMetadata.java
@@ -1,0 +1,99 @@
+package com.github.kklisura.cdt.protocol.types.emulation;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
+import java.util.List;
+
+/** Used to specify User Agent Cient Hints to emulate. See https://wicg.github.io/ua-client-hints */
+@Experimental
+public class UserAgentMetadata {
+
+  private List<UserAgentBrandVersion> brands;
+
+  private String fullVersion;
+
+  private String platform;
+
+  private String platformVersion;
+
+  private String architecture;
+
+  private String model;
+
+  private Boolean mobile;
+
+  public List<UserAgentBrandVersion> getBrands() {
+    return brands;
+  }
+
+  public void setBrands(List<UserAgentBrandVersion> brands) {
+    this.brands = brands;
+  }
+
+  public String getFullVersion() {
+    return fullVersion;
+  }
+
+  public void setFullVersion(String fullVersion) {
+    this.fullVersion = fullVersion;
+  }
+
+  public String getPlatform() {
+    return platform;
+  }
+
+  public void setPlatform(String platform) {
+    this.platform = platform;
+  }
+
+  public String getPlatformVersion() {
+    return platformVersion;
+  }
+
+  public void setPlatformVersion(String platformVersion) {
+    this.platformVersion = platformVersion;
+  }
+
+  public String getArchitecture() {
+    return architecture;
+  }
+
+  public void setArchitecture(String architecture) {
+    this.architecture = architecture;
+  }
+
+  public String getModel() {
+    return model;
+  }
+
+  public void setModel(String model) {
+    this.model = model;
+  }
+
+  public Boolean getMobile() {
+    return mobile;
+  }
+
+  public void setMobile(Boolean mobile) {
+    this.mobile = mobile;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/input/MouseButton.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/input/MouseButton.java
@@ -1,0 +1,38 @@
+package com.github.kklisura.cdt.protocol.types.input;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum MouseButton {
+  @JsonProperty("none")
+  NONE,
+  @JsonProperty("left")
+  LEFT,
+  @JsonProperty("middle")
+  MIDDLE,
+  @JsonProperty("right")
+  RIGHT,
+  @JsonProperty("back")
+  BACK,
+  @JsonProperty("forward")
+  FORWARD
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/layertree/CompositingReasons.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/layertree/CompositingReasons.java
@@ -1,0 +1,50 @@
+package com.github.kklisura.cdt.protocol.types.layertree;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.List;
+
+public class CompositingReasons {
+
+  @Deprecated private List<String> compositingReasons;
+
+  private List<String> compositingReasonIds;
+
+  /** A list of strings specifying reasons for the given layer to become composited. */
+  public List<String> getCompositingReasons() {
+    return compositingReasons;
+  }
+
+  /** A list of strings specifying reasons for the given layer to become composited. */
+  public void setCompositingReasons(List<String> compositingReasons) {
+    this.compositingReasons = compositingReasons;
+  }
+
+  /** A list of strings specifying reason IDs for the given layer to become composited. */
+  public List<String> getCompositingReasonIds() {
+    return compositingReasonIds;
+  }
+
+  /** A list of strings specifying reason IDs for the given layer to become composited. */
+  public void setCompositingReasonIds(List<String> compositingReasonIds) {
+    this.compositingReasonIds = compositingReasonIds;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/media/PlayerError.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/media/PlayerError.java
@@ -1,0 +1,57 @@
+package com.github.kklisura.cdt.protocol.types.media;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/** Corresponds to kMediaError */
+public class PlayerError {
+
+  private PlayerErrorType type;
+
+  private String errorCode;
+
+  public PlayerErrorType getType() {
+    return type;
+  }
+
+  public void setType(PlayerErrorType type) {
+    this.type = type;
+  }
+
+  /**
+   * When this switches to using media::Status instead of PipelineStatus we can remove "errorCode"
+   * and replace it with the fields from a Status instance. This also seems like a duplicate of the
+   * error level enum - there is a todo bug to have that level removed and use this instead.
+   * (crbug.com/1068454)
+   */
+  public String getErrorCode() {
+    return errorCode;
+  }
+
+  /**
+   * When this switches to using media::Status instead of PipelineStatus we can remove "errorCode"
+   * and replace it with the fields from a Status instance. This also seems like a duplicate of the
+   * error level enum - there is a todo bug to have that level removed and use this instead.
+   * (crbug.com/1068454)
+   */
+  public void setErrorCode(String errorCode) {
+    this.errorCode = errorCode;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/media/PlayerErrorType.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/media/PlayerErrorType.java
@@ -1,0 +1,30 @@
+package com.github.kklisura.cdt.protocol.types.media;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum PlayerErrorType {
+  @JsonProperty("pipeline_error")
+  PIPELINE_ERROR,
+  @JsonProperty("media_error")
+  MEDIA_ERROR
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/media/PlayerEvent.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/media/PlayerEvent.java
@@ -20,46 +20,19 @@ package com.github.kklisura.cdt.protocol.types.media;
  * #L%
  */
 
+/** Corresponds to kMediaEventTriggered */
 public class PlayerEvent {
-
-  private PlayerEventType type;
 
   private Double timestamp;
 
-  private String name;
-
   private String value;
 
-  public PlayerEventType getType() {
-    return type;
-  }
-
-  public void setType(PlayerEventType type) {
-    this.type = type;
-  }
-
-  /**
-   * Events are timestamped relative to the start of the player creation not relative to the start
-   * of playback.
-   */
   public Double getTimestamp() {
     return timestamp;
   }
 
-  /**
-   * Events are timestamped relative to the start of the player creation not relative to the start
-   * of playback.
-   */
   public void setTimestamp(Double timestamp) {
     this.timestamp = timestamp;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
   }
 
   public String getValue() {

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/media/PlayerMessage.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/media/PlayerMessage.java
@@ -1,0 +1,61 @@
+package com.github.kklisura.cdt.protocol.types.media;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/** Have one type per entry in MediaLogRecord::Type Corresponds to kMessage */
+public class PlayerMessage {
+
+  private PlayerMessageLevel level;
+
+  private String message;
+
+  /**
+   * Keep in sync with MediaLogMessageLevel We are currently keeping the message level 'error'
+   * separate from the PlayerError type because right now they represent different things, this one
+   * being a DVLOG(ERROR) style log message that gets printed based on what log level is selected in
+   * the UI, and the other is a representation of a media::PipelineStatus object. Soon however we're
+   * going to be moving away from using PipelineStatus for errors and introducing a new error type
+   * which should hopefully let us integrate the error log level into the PlayerError type.
+   */
+  public PlayerMessageLevel getLevel() {
+    return level;
+  }
+
+  /**
+   * Keep in sync with MediaLogMessageLevel We are currently keeping the message level 'error'
+   * separate from the PlayerError type because right now they represent different things, this one
+   * being a DVLOG(ERROR) style log message that gets printed based on what log level is selected in
+   * the UI, and the other is a representation of a media::PipelineStatus object. Soon however we're
+   * going to be moving away from using PipelineStatus for errors and introducing a new error type
+   * which should hopefully let us integrate the error log level into the PlayerError type.
+   */
+  public void setLevel(PlayerMessageLevel level) {
+    this.level = level;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/media/PlayerMessageLevel.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/media/PlayerMessageLevel.java
@@ -1,0 +1,42 @@
+package com.github.kklisura.cdt.protocol.types.media;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Keep in sync with MediaLogMessageLevel We are currently keeping the message level 'error'
+ * separate from the PlayerError type because right now they represent different things, this one
+ * being a DVLOG(ERROR) style log message that gets printed based on what log level is selected in
+ * the UI, and the other is a representation of a media::PipelineStatus object. Soon however we're
+ * going to be moving away from using PipelineStatus for errors and introducing a new error type
+ * which should hopefully let us integrate the error log level into the PlayerError type.
+ */
+public enum PlayerMessageLevel {
+  @JsonProperty("error")
+  ERROR,
+  @JsonProperty("warning")
+  WARNING,
+  @JsonProperty("info")
+  INFO,
+  @JsonProperty("debug")
+  DEBUG
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/media/PlayerProperty.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/media/PlayerProperty.java
@@ -20,14 +20,12 @@ package com.github.kklisura.cdt.protocol.types.media;
  * #L%
  */
 
-import com.github.kklisura.cdt.protocol.support.annotations.Optional;
-
-/** Player Property type */
+/** Corresponds to kMediaPropertyChange */
 public class PlayerProperty {
 
   private String name;
 
-  @Optional private String value;
+  private String value;
 
   public String getName() {
     return name;

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/network/BlockedCookieWithReason.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/network/BlockedCookieWithReason.java
@@ -21,23 +21,24 @@ package com.github.kklisura.cdt.protocol.types.network;
  */
 
 import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
+import java.util.List;
 
 /** A cookie with was not sent with a request with the corresponding reason. */
 @Experimental
 public class BlockedCookieWithReason {
 
-  private CookieBlockedReason blockedReason;
+  private List<CookieBlockedReason> blockedReasons;
 
   private Cookie cookie;
 
-  /** The reason the cookie was blocked. */
-  public CookieBlockedReason getBlockedReason() {
-    return blockedReason;
+  /** The reason(s) the cookie was blocked. */
+  public List<CookieBlockedReason> getBlockedReasons() {
+    return blockedReasons;
   }
 
-  /** The reason the cookie was blocked. */
-  public void setBlockedReason(CookieBlockedReason blockedReason) {
-    this.blockedReason = blockedReason;
+  /** The reason(s) the cookie was blocked. */
+  public void setBlockedReasons(List<CookieBlockedReason> blockedReasons) {
+    this.blockedReasons = blockedReasons;
   }
 
   /** The cookie object representing the cookie which was not sent. */

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/network/BlockedReason.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/network/BlockedReason.java
@@ -39,5 +39,15 @@ public enum BlockedReason {
   @JsonProperty("content-type")
   CONTENT_TYPE,
   @JsonProperty("collapsed-by-client")
-  COLLAPSED_BY_CLIENT
+  COLLAPSED_BY_CLIENT,
+  @JsonProperty("coep-frame-resource-needs-coep-header")
+  COEP_FRAME_RESOURCE_NEEDS_COEP_HEADER,
+  @JsonProperty("coop-sandboxed-iframe-cannot-navigate-to-coop-page")
+  COOP_SANDBOXED_IFRAME_CANNOT_NAVIGATE_TO_COOP_PAGE,
+  @JsonProperty("corp-not-same-origin")
+  CORP_NOT_SAME_ORIGIN,
+  @JsonProperty("corp-not-same-origin-after-defaulted-to-same-origin-by-coep")
+  CORP_NOT_SAME_ORIGIN_AFTER_DEFAULTED_TO_SAME_ORIGIN_BY_COEP,
+  @JsonProperty("corp-not-same-site")
+  CORP_NOT_SAME_SITE
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/network/BlockedSetCookieWithReason.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/network/BlockedSetCookieWithReason.java
@@ -22,25 +22,26 @@ package com.github.kklisura.cdt.protocol.types.network;
 
 import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
 import com.github.kklisura.cdt.protocol.support.annotations.Optional;
+import java.util.List;
 
 /** A cookie which was not stored from a response with the corresponding reason. */
 @Experimental
 public class BlockedSetCookieWithReason {
 
-  private SetCookieBlockedReason blockedReason;
+  private List<SetCookieBlockedReason> blockedReasons;
 
   private String cookieLine;
 
   @Optional private Cookie cookie;
 
-  /** The reason this cookie was blocked. */
-  public SetCookieBlockedReason getBlockedReason() {
-    return blockedReason;
+  /** The reason(s) this cookie was blocked. */
+  public List<SetCookieBlockedReason> getBlockedReasons() {
+    return blockedReasons;
   }
 
-  /** The reason this cookie was blocked. */
-  public void setBlockedReason(SetCookieBlockedReason blockedReason) {
-    this.blockedReason = blockedReason;
+  /** The reason(s) this cookie was blocked. */
+  public void setBlockedReasons(List<SetCookieBlockedReason> blockedReasons) {
+    this.blockedReasons = blockedReasons;
   }
 
   /**

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/network/Cookie.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/network/Cookie.java
@@ -20,6 +20,7 @@ package com.github.kklisura.cdt.protocol.types.network;
  * #L%
  */
 
+import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
 import com.github.kklisura.cdt.protocol.support.annotations.Optional;
 
 /** Cookie object */
@@ -44,6 +45,8 @@ public class Cookie {
   private Boolean session;
 
   @Optional private CookieSameSite sameSite;
+
+  @Experimental private CookiePriority priority;
 
   /** Cookie name. */
   public String getName() {
@@ -143,5 +146,15 @@ public class Cookie {
   /** Cookie SameSite type. */
   public void setSameSite(CookieSameSite sameSite) {
     this.sameSite = sameSite;
+  }
+
+  /** Cookie Priority */
+  public CookiePriority getPriority() {
+    return priority;
+  }
+
+  /** Cookie Priority */
+  public void setPriority(CookiePriority priority) {
+    this.priority = priority;
   }
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/network/CookieBlockedReason.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/network/CookieBlockedReason.java
@@ -34,8 +34,6 @@ public enum CookieBlockedReason {
   SAME_SITE_STRICT,
   @JsonProperty("SameSiteLax")
   SAME_SITE_LAX,
-  @JsonProperty("SameSiteExtended")
-  SAME_SITE_EXTENDED,
   @JsonProperty("SameSiteUnspecifiedTreatedAsLax")
   SAME_SITE_UNSPECIFIED_TREATED_AS_LAX,
   @JsonProperty("SameSiteNoneInsecure")

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/network/CookieParam.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/network/CookieParam.java
@@ -20,6 +20,7 @@ package com.github.kklisura.cdt.protocol.types.network;
  * #L%
  */
 
+import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
 import com.github.kklisura.cdt.protocol.support.annotations.Optional;
 
 /** Cookie parameter object */
@@ -42,6 +43,8 @@ public class CookieParam {
   @Optional private CookieSameSite sameSite;
 
   @Optional private Double expires;
+
+  @Experimental @Optional private CookiePriority priority;
 
   /** Cookie name. */
   public String getName() {
@@ -137,5 +140,15 @@ public class CookieParam {
   /** Cookie expiration date, session cookie if not set */
   public void setExpires(Double expires) {
     this.expires = expires;
+  }
+
+  /** Cookie Priority. */
+  public CookiePriority getPriority() {
+    return priority;
+  }
+
+  /** Cookie Priority. */
+  public void setPriority(CookiePriority priority) {
+    this.priority = priority;
   }
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/network/CookiePriority.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/network/CookiePriority.java
@@ -1,4 +1,4 @@
-package com.github.kklisura.cdt.protocol.events.page;
+package com.github.kklisura.cdt.protocol.types.network;
 
 /*-
  * #%L
@@ -22,20 +22,15 @@ package com.github.kklisura.cdt.protocol.events.page;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/** The reason for the navigation. */
-public enum FrameScheduledNavigationReason {
-  @JsonProperty("formSubmissionGet")
-  FORM_SUBMISSION_GET,
-  @JsonProperty("formSubmissionPost")
-  FORM_SUBMISSION_POST,
-  @JsonProperty("httpHeaderRefresh")
-  HTTP_HEADER_REFRESH,
-  @JsonProperty("scriptInitiated")
-  SCRIPT_INITIATED,
-  @JsonProperty("metaTagRefresh")
-  META_TAG_REFRESH,
-  @JsonProperty("pageBlockInterstitial")
-  PAGE_BLOCK_INTERSTITIAL,
-  @JsonProperty("reload")
-  RELOAD
+/**
+ * Represents the cookie's 'Priority' status:
+ * https://tools.ietf.org/html/draft-west-cookie-priority-00
+ */
+public enum CookiePriority {
+  @JsonProperty("Low")
+  LOW,
+  @JsonProperty("Medium")
+  MEDIUM,
+  @JsonProperty("High")
+  HIGH
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/network/CookieSameSite.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/network/CookieSameSite.java
@@ -31,8 +31,6 @@ public enum CookieSameSite {
   STRICT,
   @JsonProperty("Lax")
   LAX,
-  @JsonProperty("Extended")
-  EXTENDED,
   @JsonProperty("None")
   NONE
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/network/ResourceTiming.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/network/ResourceTiming.java
@@ -47,6 +47,10 @@ public class ResourceTiming {
 
   @Experimental private Double workerReady;
 
+  @Experimental private Double workerFetchStart;
+
+  @Experimental private Double workerRespondWithSettled;
+
   private Double sendStart;
 
   private Double sendEnd;
@@ -171,6 +175,26 @@ public class ResourceTiming {
   /** Finished Starting ServiceWorker. */
   public void setWorkerReady(Double workerReady) {
     this.workerReady = workerReady;
+  }
+
+  /** Started fetch event. */
+  public Double getWorkerFetchStart() {
+    return workerFetchStart;
+  }
+
+  /** Started fetch event. */
+  public void setWorkerFetchStart(Double workerFetchStart) {
+    this.workerFetchStart = workerFetchStart;
+  }
+
+  /** Settled fetch event respondWith promise. */
+  public Double getWorkerRespondWithSettled() {
+    return workerRespondWithSettled;
+  }
+
+  /** Settled fetch event respondWith promise. */
+  public void setWorkerRespondWithSettled(Double workerRespondWithSettled) {
+    this.workerRespondWithSettled = workerRespondWithSettled;
   }
 
   /** Started sending request. */

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/network/SetCookieBlockedReason.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/network/SetCookieBlockedReason.java
@@ -30,8 +30,6 @@ public enum SetCookieBlockedReason {
   SAME_SITE_STRICT,
   @JsonProperty("SameSiteLax")
   SAME_SITE_LAX,
-  @JsonProperty("SameSiteExtended")
-  SAME_SITE_EXTENDED,
   @JsonProperty("SameSiteUnspecifiedTreatedAsLax")
   SAME_SITE_UNSPECIFIED_TREATED_AS_LAX,
   @JsonProperty("SameSiteNoneInsecure")

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/overlay/ColorFormat.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/overlay/ColorFormat.java
@@ -1,0 +1,32 @@
+package com.github.kklisura.cdt.protocol.types.overlay;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum ColorFormat {
+  @JsonProperty("rgb")
+  RGB,
+  @JsonProperty("hsl")
+  HSL,
+  @JsonProperty("hex")
+  HEX
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/overlay/GridHighlightConfig.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/overlay/GridHighlightConfig.java
@@ -1,0 +1,136 @@
+package com.github.kklisura.cdt.protocol.types.overlay;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.support.annotations.Optional;
+import com.github.kklisura.cdt.protocol.types.dom.RGBA;
+
+/** Configuration data for the highlighting of Grid elements. */
+public class GridHighlightConfig {
+
+  @Optional private Boolean showGridExtensionLines;
+
+  @Optional private RGBA gridBorderColor;
+
+  @Optional private RGBA cellBorderColor;
+
+  @Optional private Boolean gridBorderDash;
+
+  @Optional private Boolean cellBorderDash;
+
+  @Optional private RGBA rowGapColor;
+
+  @Optional private RGBA rowHatchColor;
+
+  @Optional private RGBA columnGapColor;
+
+  @Optional private RGBA columnHatchColor;
+
+  /** Whether the extension lines from grid cells to the rulers should be shown (default: false). */
+  public Boolean getShowGridExtensionLines() {
+    return showGridExtensionLines;
+  }
+
+  /** Whether the extension lines from grid cells to the rulers should be shown (default: false). */
+  public void setShowGridExtensionLines(Boolean showGridExtensionLines) {
+    this.showGridExtensionLines = showGridExtensionLines;
+  }
+
+  /** The grid container border highlight color (default: transparent). */
+  public RGBA getGridBorderColor() {
+    return gridBorderColor;
+  }
+
+  /** The grid container border highlight color (default: transparent). */
+  public void setGridBorderColor(RGBA gridBorderColor) {
+    this.gridBorderColor = gridBorderColor;
+  }
+
+  /** The cell border color (default: transparent). */
+  public RGBA getCellBorderColor() {
+    return cellBorderColor;
+  }
+
+  /** The cell border color (default: transparent). */
+  public void setCellBorderColor(RGBA cellBorderColor) {
+    this.cellBorderColor = cellBorderColor;
+  }
+
+  /** Whether the grid border is dashed (default: false). */
+  public Boolean getGridBorderDash() {
+    return gridBorderDash;
+  }
+
+  /** Whether the grid border is dashed (default: false). */
+  public void setGridBorderDash(Boolean gridBorderDash) {
+    this.gridBorderDash = gridBorderDash;
+  }
+
+  /** Whether the cell border is dashed (default: false). */
+  public Boolean getCellBorderDash() {
+    return cellBorderDash;
+  }
+
+  /** Whether the cell border is dashed (default: false). */
+  public void setCellBorderDash(Boolean cellBorderDash) {
+    this.cellBorderDash = cellBorderDash;
+  }
+
+  /** The row gap highlight fill color (default: transparent). */
+  public RGBA getRowGapColor() {
+    return rowGapColor;
+  }
+
+  /** The row gap highlight fill color (default: transparent). */
+  public void setRowGapColor(RGBA rowGapColor) {
+    this.rowGapColor = rowGapColor;
+  }
+
+  /** The row gap hatching fill color (default: transparent). */
+  public RGBA getRowHatchColor() {
+    return rowHatchColor;
+  }
+
+  /** The row gap hatching fill color (default: transparent). */
+  public void setRowHatchColor(RGBA rowHatchColor) {
+    this.rowHatchColor = rowHatchColor;
+  }
+
+  /** The column gap highlight fill color (default: transparent). */
+  public RGBA getColumnGapColor() {
+    return columnGapColor;
+  }
+
+  /** The column gap highlight fill color (default: transparent). */
+  public void setColumnGapColor(RGBA columnGapColor) {
+    this.columnGapColor = columnGapColor;
+  }
+
+  /** The column gap hatching fill color (default: transparent). */
+  public RGBA getColumnHatchColor() {
+    return columnHatchColor;
+  }
+
+  /** The column gap hatching fill color (default: transparent). */
+  public void setColumnHatchColor(RGBA columnHatchColor) {
+    this.columnHatchColor = columnHatchColor;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/overlay/HighlightConfig.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/overlay/HighlightConfig.java
@@ -50,6 +50,10 @@ public class HighlightConfig {
 
   @Optional private RGBA cssGridColor;
 
+  @Optional private ColorFormat colorFormat;
+
+  @Optional private GridHighlightConfig gridHighlightConfig;
+
   /** Whether the node info tooltip should be shown (default: false). */
   public Boolean getShowInfo() {
     return showInfo;
@@ -168,5 +172,25 @@ public class HighlightConfig {
   /** The grid layout color (default: transparent). */
   public void setCssGridColor(RGBA cssGridColor) {
     this.cssGridColor = cssGridColor;
+  }
+
+  /** The color format used to format color styles (default: hex). */
+  public ColorFormat getColorFormat() {
+    return colorFormat;
+  }
+
+  /** The color format used to format color styles (default: hex). */
+  public void setColorFormat(ColorFormat colorFormat) {
+    this.colorFormat = colorFormat;
+  }
+
+  /** The grid layout highlight configuration (default: all transparent). */
+  public GridHighlightConfig getGridHighlightConfig() {
+    return gridHighlightConfig;
+  }
+
+  /** The grid layout highlight configuration (default: all transparent). */
+  public void setGridHighlightConfig(GridHighlightConfig gridHighlightConfig) {
+    this.gridHighlightConfig = gridHighlightConfig;
   }
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/overlay/HingeConfig.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/overlay/HingeConfig.java
@@ -1,0 +1,65 @@
+package com.github.kklisura.cdt.protocol.types.overlay;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.support.annotations.Optional;
+import com.github.kklisura.cdt.protocol.types.dom.RGBA;
+import com.github.kklisura.cdt.protocol.types.dom.Rect;
+
+/** Configuration for dual screen hinge */
+public class HingeConfig {
+
+  private Rect rect;
+
+  @Optional private RGBA contentColor;
+
+  @Optional private RGBA outlineColor;
+
+  /** A rectangle represent hinge */
+  public Rect getRect() {
+    return rect;
+  }
+
+  /** A rectangle represent hinge */
+  public void setRect(Rect rect) {
+    this.rect = rect;
+  }
+
+  /** The content box highlight fill color (default: a dark color). */
+  public RGBA getContentColor() {
+    return contentColor;
+  }
+
+  /** The content box highlight fill color (default: a dark color). */
+  public void setContentColor(RGBA contentColor) {
+    this.contentColor = contentColor;
+  }
+
+  /** The content box highlight outline color (default: transparent). */
+  public RGBA getOutlineColor() {
+    return outlineColor;
+  }
+
+  /** The content box highlight outline color (default: transparent). */
+  public void setOutlineColor(RGBA outlineColor) {
+    this.outlineColor = outlineColor;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/page/AppManifest.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/page/AppManifest.java
@@ -20,6 +20,7 @@ package com.github.kklisura.cdt.protocol.types.page;
  * #L%
  */
 
+import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
 import com.github.kklisura.cdt.protocol.support.annotations.Optional;
 import java.util.List;
 
@@ -30,6 +31,8 @@ public class AppManifest {
   private List<AppManifestError> errors;
 
   @Optional private String data;
+
+  @Experimental @Optional private AppManifestParsedProperties parsed;
 
   /** Manifest location. */
   public String getUrl() {
@@ -57,5 +60,15 @@ public class AppManifest {
   /** Manifest content. */
   public void setData(String data) {
     this.data = data;
+  }
+
+  /** Parsed manifest properties */
+  public AppManifestParsedProperties getParsed() {
+    return parsed;
+  }
+
+  /** Parsed manifest properties */
+  public void setParsed(AppManifestParsedProperties parsed) {
+    this.parsed = parsed;
   }
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/page/AppManifestParsedProperties.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/page/AppManifestParsedProperties.java
@@ -1,0 +1,40 @@
+package com.github.kklisura.cdt.protocol.types.page;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
+
+/** Parsed app manifest properties. */
+@Experimental
+public class AppManifestParsedProperties {
+
+  private String scope;
+
+  /** Computed scope value */
+  public String getScope() {
+    return scope;
+  }
+
+  /** Computed scope value */
+  public void setScope(String scope) {
+    this.scope = scope;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/page/ClientNavigationDisposition.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/page/ClientNavigationDisposition.java
@@ -1,0 +1,34 @@
+package com.github.kklisura.cdt.protocol.types.page;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum ClientNavigationDisposition {
+  @JsonProperty("currentTab")
+  CURRENT_TAB,
+  @JsonProperty("newTab")
+  NEW_TAB,
+  @JsonProperty("newWindow")
+  NEW_WINDOW,
+  @JsonProperty("download")
+  DOWNLOAD
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/page/ClientNavigationReason.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/page/ClientNavigationReason.java
@@ -36,5 +36,7 @@ public enum ClientNavigationReason {
   @JsonProperty("pageBlockInterstitial")
   PAGE_BLOCK_INTERSTITIAL,
   @JsonProperty("reload")
-  RELOAD
+  RELOAD,
+  @JsonProperty("anchorClick")
+  ANCHOR_CLICK
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/page/InstallabilityError.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/page/InstallabilityError.java
@@ -1,0 +1,53 @@
+package com.github.kklisura.cdt.protocol.types.page;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
+import java.util.List;
+
+/** The installability error */
+@Experimental
+public class InstallabilityError {
+
+  private String errorId;
+
+  private List<InstallabilityErrorArgument> errorArguments;
+
+  /** The error id (e.g. 'manifest-missing-suitable-icon'). */
+  public String getErrorId() {
+    return errorId;
+  }
+
+  /** The error id (e.g. 'manifest-missing-suitable-icon'). */
+  public void setErrorId(String errorId) {
+    this.errorId = errorId;
+  }
+
+  /** The list of error arguments (e.g. {name:'minimum-icon-size-in-pixels', value:'64'}). */
+  public List<InstallabilityErrorArgument> getErrorArguments() {
+    return errorArguments;
+  }
+
+  /** The list of error arguments (e.g. {name:'minimum-icon-size-in-pixels', value:'64'}). */
+  public void setErrorArguments(List<InstallabilityErrorArgument> errorArguments) {
+    this.errorArguments = errorArguments;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/page/InstallabilityErrorArgument.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/page/InstallabilityErrorArgument.java
@@ -1,0 +1,51 @@
+package com.github.kklisura.cdt.protocol.types.page;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
+
+@Experimental
+public class InstallabilityErrorArgument {
+
+  private String name;
+
+  private String value;
+
+  /** Argument name (e.g. name:'minimum-icon-size-in-pixels'). */
+  public String getName() {
+    return name;
+  }
+
+  /** Argument name (e.g. name:'minimum-icon-size-in-pixels'). */
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /** Argument value (e.g. value:'64'). */
+  public String getValue() {
+    return value;
+  }
+
+  /** Argument value (e.g. value:'64'). */
+  public void setValue(String value) {
+    this.value = value;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/page/ReferrerPolicy.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/page/ReferrerPolicy.java
@@ -1,0 +1,43 @@
+package com.github.kklisura.cdt.protocol.types.page;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** The referring-policy used for the navigation. */
+public enum ReferrerPolicy {
+  @JsonProperty("noReferrer")
+  NO_REFERRER,
+  @JsonProperty("noReferrerWhenDowngrade")
+  NO_REFERRER_WHEN_DOWNGRADE,
+  @JsonProperty("origin")
+  ORIGIN,
+  @JsonProperty("originWhenCrossOrigin")
+  ORIGIN_WHEN_CROSS_ORIGIN,
+  @JsonProperty("sameOrigin")
+  SAME_ORIGIN,
+  @JsonProperty("strictOrigin")
+  STRICT_ORIGIN,
+  @JsonProperty("strictOriginWhenCrossOrigin")
+  STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
+  @JsonProperty("unsafeUrl")
+  UNSAFE_URL
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/performance/EnableTimeDomain.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/performance/EnableTimeDomain.java
@@ -1,0 +1,31 @@
+package com.github.kklisura.cdt.protocol.types.performance;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Time domain to use for collecting and reporting duration metrics. */
+public enum EnableTimeDomain {
+  @JsonProperty("timeTicks")
+  TIME_TICKS,
+  @JsonProperty("threadTicks")
+  THREAD_TICKS
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/profiler/CounterInfo.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/profiler/CounterInfo.java
@@ -1,0 +1,52 @@
+package com.github.kklisura.cdt.protocol.types.profiler;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
+
+/** Collected counter information. */
+@Experimental
+public class CounterInfo {
+
+  private String name;
+
+  private Integer value;
+
+  /** Counter name. */
+  public String getName() {
+    return name;
+  }
+
+  /** Counter name. */
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /** Counter value. */
+  public Integer getValue() {
+    return value;
+  }
+
+  /** Counter value. */
+  public void setValue(Integer value) {
+    this.value = value;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/profiler/TakePreciseCoverage.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/profiler/TakePreciseCoverage.java
@@ -1,0 +1,54 @@
+package com.github.kklisura.cdt.protocol.types.profiler;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.List;
+
+public class TakePreciseCoverage {
+
+  private List<ScriptCoverage> result;
+
+  private Double timestamp;
+
+  /** Coverage data for the current isolate. */
+  public List<ScriptCoverage> getResult() {
+    return result;
+  }
+
+  /** Coverage data for the current isolate. */
+  public void setResult(List<ScriptCoverage> result) {
+    this.result = result;
+  }
+
+  /**
+   * Monotonically increasing time (in seconds) when the coverage update was taken in the backend.
+   */
+  public Double getTimestamp() {
+    return timestamp;
+  }
+
+  /**
+   * Monotonically increasing time (in seconds) when the coverage update was taken in the backend.
+   */
+  public void setTimestamp(Double timestamp) {
+    this.timestamp = timestamp;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/runtime/PrivatePropertyDescriptor.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/runtime/PrivatePropertyDescriptor.java
@@ -21,6 +21,7 @@ package com.github.kklisura.cdt.protocol.types.runtime;
  */
 
 import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
+import com.github.kklisura.cdt.protocol.support.annotations.Optional;
 
 /** Object private field descriptor. */
 @Experimental
@@ -28,7 +29,11 @@ public class PrivatePropertyDescriptor {
 
   private String name;
 
-  private RemoteObject value;
+  @Optional private RemoteObject value;
+
+  @Optional private RemoteObject get;
+
+  @Optional private RemoteObject set;
 
   /** Private property name. */
   public String getName() {
@@ -48,5 +53,37 @@ public class PrivatePropertyDescriptor {
   /** The value associated with the private property. */
   public void setValue(RemoteObject value) {
     this.value = value;
+  }
+
+  /**
+   * A function which serves as a getter for the private property, or `undefined` if there is no
+   * getter (accessor descriptors only).
+   */
+  public RemoteObject getGet() {
+    return get;
+  }
+
+  /**
+   * A function which serves as a getter for the private property, or `undefined` if there is no
+   * getter (accessor descriptors only).
+   */
+  public void setGet(RemoteObject get) {
+    this.get = get;
+  }
+
+  /**
+   * A function which serves as a setter for the private property, or `undefined` if there is no
+   * setter (accessor descriptors only).
+   */
+  public RemoteObject getSet() {
+    return set;
+  }
+
+  /**
+   * A function which serves as a setter for the private property, or `undefined` if there is no
+   * setter (accessor descriptors only).
+   */
+  public void setSet(RemoteObject set) {
+    this.set = set;
   }
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/runtime/RemoteObject.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/runtime/RemoteObject.java
@@ -54,12 +54,12 @@ public class RemoteObject {
     this.type = type;
   }
 
-  /** Object subtype hint. Specified for `object` type values only. */
+  /** Object subtype hint. Specified for `object` or `wasm` type values only. */
   public RemoteObjectSubtype getSubtype() {
     return subtype;
   }
 
-  /** Object subtype hint. Specified for `object` type values only. */
+  /** Object subtype hint. Specified for `object` or `wasm` type values only. */
   public void setSubtype(RemoteObjectSubtype subtype) {
     this.subtype = subtype;
   }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/runtime/RemoteObjectSubtype.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/runtime/RemoteObjectSubtype.java
@@ -22,7 +22,7 @@ package com.github.kklisura.cdt.protocol.types.runtime;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/** Object subtype hint. Specified for `object` type values only. */
+/** Object subtype hint. Specified for `object` or `wasm` type values only. */
 public enum RemoteObjectSubtype {
   @JsonProperty("array")
   ARRAY,
@@ -57,5 +57,17 @@ public enum RemoteObjectSubtype {
   @JsonProperty("arraybuffer")
   ARRAYBUFFER,
   @JsonProperty("dataview")
-  DATAVIEW
+  DATAVIEW,
+  @JsonProperty("i32")
+  I_32,
+  @JsonProperty("i64")
+  I_64,
+  @JsonProperty("f32")
+  F_32,
+  @JsonProperty("f64")
+  F_64,
+  @JsonProperty("v128")
+  V_128,
+  @JsonProperty("anyref")
+  ANYREF
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/runtime/RemoteObjectType.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/runtime/RemoteObjectType.java
@@ -39,5 +39,7 @@ public enum RemoteObjectType {
   @JsonProperty("symbol")
   SYMBOL,
   @JsonProperty("bigint")
-  BIGINT
+  BIGINT,
+  @JsonProperty("wasm")
+  WASM
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/security/CertificateSecurityState.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/security/CertificateSecurityState.java
@@ -1,0 +1,246 @@
+package com.github.kklisura.cdt.protocol.types.security;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
+import com.github.kklisura.cdt.protocol.support.annotations.Optional;
+import java.util.List;
+
+/** Details about the security state of the page certificate. */
+@Experimental
+public class CertificateSecurityState {
+
+  private String protocol;
+
+  private String keyExchange;
+
+  @Optional private String keyExchangeGroup;
+
+  private String cipher;
+
+  @Optional private String mac;
+
+  private List<String> certificate;
+
+  private String subjectName;
+
+  private String issuer;
+
+  private Double validFrom;
+
+  private Double validTo;
+
+  @Optional private String certificateNetworkError;
+
+  private Boolean certificateHasWeakSignature;
+
+  private Boolean certificateHasSha1Signature;
+
+  private Boolean modernSSL;
+
+  private Boolean obsoleteSslProtocol;
+
+  private Boolean obsoleteSslKeyExchange;
+
+  private Boolean obsoleteSslCipher;
+
+  private Boolean obsoleteSslSignature;
+
+  /** Protocol name (e.g. "TLS 1.2" or "QUIC"). */
+  public String getProtocol() {
+    return protocol;
+  }
+
+  /** Protocol name (e.g. "TLS 1.2" or "QUIC"). */
+  public void setProtocol(String protocol) {
+    this.protocol = protocol;
+  }
+
+  /** Key Exchange used by the connection, or the empty string if not applicable. */
+  public String getKeyExchange() {
+    return keyExchange;
+  }
+
+  /** Key Exchange used by the connection, or the empty string if not applicable. */
+  public void setKeyExchange(String keyExchange) {
+    this.keyExchange = keyExchange;
+  }
+
+  /** (EC)DH group used by the connection, if applicable. */
+  public String getKeyExchangeGroup() {
+    return keyExchangeGroup;
+  }
+
+  /** (EC)DH group used by the connection, if applicable. */
+  public void setKeyExchangeGroup(String keyExchangeGroup) {
+    this.keyExchangeGroup = keyExchangeGroup;
+  }
+
+  /** Cipher name. */
+  public String getCipher() {
+    return cipher;
+  }
+
+  /** Cipher name. */
+  public void setCipher(String cipher) {
+    this.cipher = cipher;
+  }
+
+  /** TLS MAC. Note that AEAD ciphers do not have separate MACs. */
+  public String getMac() {
+    return mac;
+  }
+
+  /** TLS MAC. Note that AEAD ciphers do not have separate MACs. */
+  public void setMac(String mac) {
+    this.mac = mac;
+  }
+
+  /** Page certificate. */
+  public List<String> getCertificate() {
+    return certificate;
+  }
+
+  /** Page certificate. */
+  public void setCertificate(List<String> certificate) {
+    this.certificate = certificate;
+  }
+
+  /** Certificate subject name. */
+  public String getSubjectName() {
+    return subjectName;
+  }
+
+  /** Certificate subject name. */
+  public void setSubjectName(String subjectName) {
+    this.subjectName = subjectName;
+  }
+
+  /** Name of the issuing CA. */
+  public String getIssuer() {
+    return issuer;
+  }
+
+  /** Name of the issuing CA. */
+  public void setIssuer(String issuer) {
+    this.issuer = issuer;
+  }
+
+  /** Certificate valid from date. */
+  public Double getValidFrom() {
+    return validFrom;
+  }
+
+  /** Certificate valid from date. */
+  public void setValidFrom(Double validFrom) {
+    this.validFrom = validFrom;
+  }
+
+  /** Certificate valid to (expiration) date */
+  public Double getValidTo() {
+    return validTo;
+  }
+
+  /** Certificate valid to (expiration) date */
+  public void setValidTo(Double validTo) {
+    this.validTo = validTo;
+  }
+
+  /** The highest priority network error code, if the certificate has an error. */
+  public String getCertificateNetworkError() {
+    return certificateNetworkError;
+  }
+
+  /** The highest priority network error code, if the certificate has an error. */
+  public void setCertificateNetworkError(String certificateNetworkError) {
+    this.certificateNetworkError = certificateNetworkError;
+  }
+
+  /** True if the certificate uses a weak signature aglorithm. */
+  public Boolean getCertificateHasWeakSignature() {
+    return certificateHasWeakSignature;
+  }
+
+  /** True if the certificate uses a weak signature aglorithm. */
+  public void setCertificateHasWeakSignature(Boolean certificateHasWeakSignature) {
+    this.certificateHasWeakSignature = certificateHasWeakSignature;
+  }
+
+  /** True if the certificate has a SHA1 signature in the chain. */
+  public Boolean getCertificateHasSha1Signature() {
+    return certificateHasSha1Signature;
+  }
+
+  /** True if the certificate has a SHA1 signature in the chain. */
+  public void setCertificateHasSha1Signature(Boolean certificateHasSha1Signature) {
+    this.certificateHasSha1Signature = certificateHasSha1Signature;
+  }
+
+  /** True if modern SSL */
+  public Boolean getModernSSL() {
+    return modernSSL;
+  }
+
+  /** True if modern SSL */
+  public void setModernSSL(Boolean modernSSL) {
+    this.modernSSL = modernSSL;
+  }
+
+  /** True if the connection is using an obsolete SSL protocol. */
+  public Boolean getObsoleteSslProtocol() {
+    return obsoleteSslProtocol;
+  }
+
+  /** True if the connection is using an obsolete SSL protocol. */
+  public void setObsoleteSslProtocol(Boolean obsoleteSslProtocol) {
+    this.obsoleteSslProtocol = obsoleteSslProtocol;
+  }
+
+  /** True if the connection is using an obsolete SSL key exchange. */
+  public Boolean getObsoleteSslKeyExchange() {
+    return obsoleteSslKeyExchange;
+  }
+
+  /** True if the connection is using an obsolete SSL key exchange. */
+  public void setObsoleteSslKeyExchange(Boolean obsoleteSslKeyExchange) {
+    this.obsoleteSslKeyExchange = obsoleteSslKeyExchange;
+  }
+
+  /** True if the connection is using an obsolete SSL cipher. */
+  public Boolean getObsoleteSslCipher() {
+    return obsoleteSslCipher;
+  }
+
+  /** True if the connection is using an obsolete SSL cipher. */
+  public void setObsoleteSslCipher(Boolean obsoleteSslCipher) {
+    this.obsoleteSslCipher = obsoleteSslCipher;
+  }
+
+  /** True if the connection is using an obsolete SSL signature. */
+  public Boolean getObsoleteSslSignature() {
+    return obsoleteSslSignature;
+  }
+
+  /** True if the connection is using an obsolete SSL signature. */
+  public void setObsoleteSslSignature(Boolean obsoleteSslSignature) {
+    this.obsoleteSslSignature = obsoleteSslSignature;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/security/SafetyTipInfo.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/security/SafetyTipInfo.java
@@ -1,0 +1,56 @@
+package com.github.kklisura.cdt.protocol.types.security;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
+import com.github.kklisura.cdt.protocol.support.annotations.Optional;
+
+@Experimental
+public class SafetyTipInfo {
+
+  private SafetyTipStatus safetyTipStatus;
+
+  @Optional private String safeUrl;
+
+  /**
+   * Describes whether the page triggers any safety tips or reputation warnings. Default is unknown.
+   */
+  public SafetyTipStatus getSafetyTipStatus() {
+    return safetyTipStatus;
+  }
+
+  /**
+   * Describes whether the page triggers any safety tips or reputation warnings. Default is unknown.
+   */
+  public void setSafetyTipStatus(SafetyTipStatus safetyTipStatus) {
+    this.safetyTipStatus = safetyTipStatus;
+  }
+
+  /** The URL the safety tip suggested ("Did you mean?"). Only filled in for lookalike matches. */
+  public String getSafeUrl() {
+    return safeUrl;
+  }
+
+  /** The URL the safety tip suggested ("Did you mean?"). Only filled in for lookalike matches. */
+  public void setSafeUrl(String safeUrl) {
+    this.safeUrl = safeUrl;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/security/SafetyTipStatus.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/security/SafetyTipStatus.java
@@ -1,0 +1,30 @@
+package com.github.kklisura.cdt.protocol.types.security;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum SafetyTipStatus {
+  @JsonProperty("badReputation")
+  BAD_REPUTATION,
+  @JsonProperty("lookalike")
+  LOOKALIKE
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/security/SecurityState.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/security/SecurityState.java
@@ -33,5 +33,7 @@ public enum SecurityState {
   @JsonProperty("secure")
   SECURE,
   @JsonProperty("info")
-  INFO
+  INFO,
+  @JsonProperty("insecure-broken")
+  INSECURE_BROKEN
 }

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/security/VisibleSecurityState.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/security/VisibleSecurityState.java
@@ -1,0 +1,84 @@
+package com.github.kklisura.cdt.protocol.types.security;
+
+/*-
+ * #%L
+ * cdt-java-client
+ * %%
+ * Copyright (C) 2018 - 2019 Kenan Klisura
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.github.kklisura.cdt.protocol.support.annotations.Experimental;
+import com.github.kklisura.cdt.protocol.support.annotations.Optional;
+import java.util.List;
+
+/** Security state information about the page. */
+@Experimental
+public class VisibleSecurityState {
+
+  private SecurityState securityState;
+
+  @Optional private CertificateSecurityState certificateSecurityState;
+
+  @Optional private SafetyTipInfo safetyTipInfo;
+
+  private List<String> securityStateIssueIds;
+
+  /** The security level of the page. */
+  public SecurityState getSecurityState() {
+    return securityState;
+  }
+
+  /** The security level of the page. */
+  public void setSecurityState(SecurityState securityState) {
+    this.securityState = securityState;
+  }
+
+  /** Security state details about the page certificate. */
+  public CertificateSecurityState getCertificateSecurityState() {
+    return certificateSecurityState;
+  }
+
+  /** Security state details about the page certificate. */
+  public void setCertificateSecurityState(CertificateSecurityState certificateSecurityState) {
+    this.certificateSecurityState = certificateSecurityState;
+  }
+
+  /**
+   * The type of Safety Tip triggered on the page. Note that this field will be set even if the
+   * Safety Tip UI was not actually shown.
+   */
+  public SafetyTipInfo getSafetyTipInfo() {
+    return safetyTipInfo;
+  }
+
+  /**
+   * The type of Safety Tip triggered on the page. Note that this field will be set even if the
+   * Safety Tip UI was not actually shown.
+   */
+  public void setSafetyTipInfo(SafetyTipInfo safetyTipInfo) {
+    this.safetyTipInfo = safetyTipInfo;
+  }
+
+  /** Array of security state issues ids. */
+  public List<String> getSecurityStateIssueIds() {
+    return securityStateIssueIds;
+  }
+
+  /** Array of security state issues ids. */
+  public void setSecurityStateIssueIds(List<String> securityStateIssueIds) {
+    this.securityStateIssueIds = securityStateIssueIds;
+  }
+}

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/systeminfo/GPUDevice.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/systeminfo/GPUDevice.java
@@ -20,12 +20,18 @@ package com.github.kklisura.cdt.protocol.types.systeminfo;
  * #L%
  */
 
+import com.github.kklisura.cdt.protocol.support.annotations.Optional;
+
 /** Describes a single graphics processor (GPU). */
 public class GPUDevice {
 
   private Double vendorId;
 
   private Double deviceId;
+
+  @Optional private Double subSysId;
+
+  @Optional private Double revision;
 
   private String vendorString;
 
@@ -53,6 +59,26 @@ public class GPUDevice {
   /** PCI ID of the GPU device, if available; 0 otherwise. */
   public void setDeviceId(Double deviceId) {
     this.deviceId = deviceId;
+  }
+
+  /** Sub sys ID of the GPU, only available on Windows. */
+  public Double getSubSysId() {
+    return subSysId;
+  }
+
+  /** Sub sys ID of the GPU, only available on Windows. */
+  public void setSubSysId(Double subSysId) {
+    this.subSysId = subSysId;
+  }
+
+  /** Revision of the GPU, only available on Windows. */
+  public Double getRevision() {
+    return revision;
+  }
+
+  /** Revision of the GPU, only available on Windows. */
+  public void setRevision(Double revision) {
+    this.revision = revision;
   }
 
   /** String description of the GPU vendor, if the PCI ID is not available. */

--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/webauthn/VirtualAuthenticatorOptions.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/webauthn/VirtualAuthenticatorOptions.java
@@ -28,11 +28,13 @@ public class VirtualAuthenticatorOptions {
 
   private AuthenticatorTransport transport;
 
-  private Boolean hasResidentKey;
+  @Optional private Boolean hasResidentKey;
 
-  private Boolean hasUserVerification;
+  @Optional private Boolean hasUserVerification;
 
   @Optional private Boolean automaticPresenceSimulation;
+
+  @Optional private Boolean isUserVerified;
 
   public AuthenticatorProtocol getProtocol() {
     return protocol;
@@ -50,18 +52,22 @@ public class VirtualAuthenticatorOptions {
     this.transport = transport;
   }
 
+  /** Defaults to false. */
   public Boolean getHasResidentKey() {
     return hasResidentKey;
   }
 
+  /** Defaults to false. */
   public void setHasResidentKey(Boolean hasResidentKey) {
     this.hasResidentKey = hasResidentKey;
   }
 
+  /** Defaults to false. */
   public Boolean getHasUserVerification() {
     return hasUserVerification;
   }
 
+  /** Defaults to false. */
   public void setHasUserVerification(Boolean hasUserVerification) {
     this.hasUserVerification = hasUserVerification;
   }
@@ -80,5 +86,15 @@ public class VirtualAuthenticatorOptions {
    */
   public void setAutomaticPresenceSimulation(Boolean automaticPresenceSimulation) {
     this.automaticPresenceSimulation = automaticPresenceSimulation;
+  }
+
+  /** Sets whether User Verification succeeds or fails for an authenticator. Defaults to false. */
+  public Boolean getIsUserVerified() {
+    return isUserVerified;
+  }
+
+  /** Sets whether User Verification succeeds or fails for an authenticator. Defaults to false. */
+  public void setIsUserVerified(Boolean isUserVerified) {
+    this.isUserVerified = isUserVerified;
   }
 }

--- a/cdt-java-protocol-builder/THIRD-PARTY.txt
+++ b/cdt-java-protocol-builder/THIRD-PARTY.txt
@@ -68,7 +68,7 @@ Lists of 74 third-party dependencies.
      (BSD 3-Clause License) ASM Commons (org.ow2.asm:asm-commons:6.0 - http://asm.objectweb.org/asm-commons/)
      (BSD 3-Clause License) ASM Tree (org.ow2.asm:asm-tree:6.0 - http://asm.objectweb.org/asm-tree/)
      (BSD 3-Clause License) ASM Util (org.ow2.asm:asm-util:6.0 - http://asm.objectweb.org/asm-util/)
-     (The MIT License) Project Lombok (org.projectlombok:lombok:1.16.18 - https://projectlombok.org)
+     (The MIT License) Project Lombok (org.projectlombok:lombok:1.18.2 - https://projectlombok.org)
      (The Apache Software License, Version 2.0) JSONassert (org.skyscreamer:jsonassert:1.5.0 - https://github.com/skyscreamer/JSONassert)
      (MIT License) SLF4J API Module (org.slf4j:slf4j-api:1.7.25 - http://www.slf4j.org)
      (The Apache Software License, Version 2.0) oro (oro:oro:2.0.8 - no url defined)

--- a/cdt-java-protocol-builder/pom.xml
+++ b/cdt-java-protocol-builder/pom.xml
@@ -34,7 +34,7 @@
         <jackson.version>2.10.0</jackson.version>
         <apache.collections.version>4.1</apache.collections.version>
         <apache.lang3.version>3.7</apache.lang3.version>
-        <lombok.version>1.16.18</lombok.version>
+        <lombok.version>1.18.2</lombok.version>
         <logback.version>1.2.3</logback.version>
         <args4j.version>2.33</args4j.version>
         <google.java.format.version>1.5</google.java.format.version>

--- a/cdt-protocol-parser/pom.xml
+++ b/cdt-protocol-parser/pom.xml
@@ -31,7 +31,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <lombok.version>1.16.18</lombok.version>
+    <lombok.version>1.18.2</lombok.version>
     <java.parser.core.version>3.5.11</java.parser.core.version>
     <jackson.version>2.10.0</jackson.version>
     <junit.version>4.12</junit.version>

--- a/cdt-protocol-parser/src/test/resources/browser_protocol.json
+++ b/cdt-protocol-parser/src/test/resources/browser_protocol.json
@@ -740,6 +740,9 @@
         {
             "domain": "ApplicationCache",
             "experimental": true,
+            "dependencies": [
+                "Page"
+            ],
             "types": [
                 {
                     "id": "ApplicationCacheResource",
@@ -916,6 +919,290 @@
             "dependencies": [
                 "Network"
             ],
+            "types": [
+                {
+                    "id": "AffectedCookie",
+                    "description": "Information about a cookie that is affected by an inspector issue.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "name",
+                            "description": "The following three properties uniquely identify a cookie",
+                            "type": "string"
+                        },
+                        {
+                            "name": "path",
+                            "type": "string"
+                        },
+                        {
+                            "name": "domain",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "AffectedRequest",
+                    "description": "Information about a request that is affected by an inspector issue.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "requestId",
+                            "description": "The unique request id.",
+                            "$ref": "Network.RequestId"
+                        },
+                        {
+                            "name": "url",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "AffectedFrame",
+                    "description": "Information about the frame affected by an inspector issue.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "frameId",
+                            "$ref": "Page.FrameId"
+                        }
+                    ]
+                },
+                {
+                    "id": "SameSiteCookieExclusionReason",
+                    "type": "string",
+                    "enum": [
+                        "ExcludeSameSiteUnspecifiedTreatedAsLax",
+                        "ExcludeSameSiteNoneInsecure"
+                    ]
+                },
+                {
+                    "id": "SameSiteCookieWarningReason",
+                    "type": "string",
+                    "enum": [
+                        "WarnSameSiteUnspecifiedCrossSiteContext",
+                        "WarnSameSiteNoneInsecure",
+                        "WarnSameSiteUnspecifiedLaxAllowUnsafe",
+                        "WarnSameSiteStrictLaxDowngradeStrict",
+                        "WarnSameSiteStrictCrossDowngradeStrict",
+                        "WarnSameSiteStrictCrossDowngradeLax",
+                        "WarnSameSiteLaxCrossDowngradeStrict",
+                        "WarnSameSiteLaxCrossDowngradeLax"
+                    ]
+                },
+                {
+                    "id": "SameSiteCookieOperation",
+                    "type": "string",
+                    "enum": [
+                        "SetCookie",
+                        "ReadCookie"
+                    ]
+                },
+                {
+                    "id": "SameSiteCookieIssueDetails",
+                    "description": "This information is currently necessary, as the front-end has a difficult\ntime finding a specific cookie. With this, we can convey specific error\ninformation without the cookie.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "cookie",
+                            "$ref": "AffectedCookie"
+                        },
+                        {
+                            "name": "cookieWarningReasons",
+                            "type": "array",
+                            "items": {
+                                "$ref": "SameSiteCookieWarningReason"
+                            }
+                        },
+                        {
+                            "name": "cookieExclusionReasons",
+                            "type": "array",
+                            "items": {
+                                "$ref": "SameSiteCookieExclusionReason"
+                            }
+                        },
+                        {
+                            "name": "operation",
+                            "description": "Optionally identifies the site-for-cookies and the cookie url, which\nmay be used by the front-end as additional context.",
+                            "$ref": "SameSiteCookieOperation"
+                        },
+                        {
+                            "name": "siteForCookies",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "cookieUrl",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "request",
+                            "optional": true,
+                            "$ref": "AffectedRequest"
+                        }
+                    ]
+                },
+                {
+                    "id": "MixedContentResolutionStatus",
+                    "type": "string",
+                    "enum": [
+                        "MixedContentBlocked",
+                        "MixedContentAutomaticallyUpgraded",
+                        "MixedContentWarning"
+                    ]
+                },
+                {
+                    "id": "MixedContentResourceType",
+                    "type": "string",
+                    "enum": [
+                        "Audio",
+                        "Beacon",
+                        "CSPReport",
+                        "Download",
+                        "EventSource",
+                        "Favicon",
+                        "Font",
+                        "Form",
+                        "Frame",
+                        "Image",
+                        "Import",
+                        "Manifest",
+                        "Ping",
+                        "PluginData",
+                        "PluginResource",
+                        "Prefetch",
+                        "Resource",
+                        "Script",
+                        "ServiceWorker",
+                        "SharedWorker",
+                        "Stylesheet",
+                        "Track",
+                        "Video",
+                        "Worker",
+                        "XMLHttpRequest",
+                        "XSLT"
+                    ]
+                },
+                {
+                    "id": "MixedContentIssueDetails",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "resourceType",
+                            "description": "The type of resource causing the mixed content issue (css, js, iframe,\nform,...). Marked as optional because it is mapped to from\nblink::mojom::RequestContextType, which will be replaced\nby network::mojom::RequestDestination",
+                            "optional": true,
+                            "$ref": "MixedContentResourceType"
+                        },
+                        {
+                            "name": "resolutionStatus",
+                            "description": "The way the mixed content issue is being resolved.",
+                            "$ref": "MixedContentResolutionStatus"
+                        },
+                        {
+                            "name": "insecureURL",
+                            "description": "The unsafe http url causing the mixed content issue.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "mainResourceURL",
+                            "description": "The url responsible for the call to an unsafe url.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "request",
+                            "description": "The mixed content request.\nDoes not always exist (e.g. for unsafe form submission urls).",
+                            "optional": true,
+                            "$ref": "AffectedRequest"
+                        },
+                        {
+                            "name": "frame",
+                            "description": "Optional because not every mixed content issue is necessarily linked to a frame.",
+                            "optional": true,
+                            "$ref": "AffectedFrame"
+                        }
+                    ]
+                },
+                {
+                    "id": "BlockedByResponseReason",
+                    "description": "Enum indicating the reason a response has been blocked. These reasons are\nrefinements of the net error BLOCKED_BY_RESPONSE.",
+                    "type": "string",
+                    "enum": [
+                        "CoepFrameResourceNeedsCoepHeader",
+                        "CoopSandboxedIFrameCannotNavigateToCoopPage",
+                        "CorpNotSameOrigin",
+                        "CorpNotSameOriginAfterDefaultedToSameOriginByCoep",
+                        "CorpNotSameSite"
+                    ]
+                },
+                {
+                    "id": "BlockedByResponseIssueDetails",
+                    "description": "Details for a request that has been blocked with the BLOCKED_BY_RESPONSE\ncode. Currently only used for COEP/COOP, but may be extended to include\nsome CSP errors in the future.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "request",
+                            "$ref": "AffectedRequest"
+                        },
+                        {
+                            "name": "frame",
+                            "optional": true,
+                            "$ref": "AffectedFrame"
+                        },
+                        {
+                            "name": "reason",
+                            "$ref": "BlockedByResponseReason"
+                        }
+                    ]
+                },
+                {
+                    "id": "InspectorIssueCode",
+                    "description": "A unique identifier for the type of issue. Each type may use one of the\noptional fields in InspectorIssueDetails to convey more specific\ninformation about the kind of issue.",
+                    "type": "string",
+                    "enum": [
+                        "SameSiteCookieIssue",
+                        "MixedContentIssue",
+                        "BlockedByResponseIssue"
+                    ]
+                },
+                {
+                    "id": "InspectorIssueDetails",
+                    "description": "This struct holds a list of optional fields with additional information\nspecific to the kind of issue. When adding a new issue code, please also\nadd a new optional field to this type.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "sameSiteCookieIssueDetails",
+                            "optional": true,
+                            "$ref": "SameSiteCookieIssueDetails"
+                        },
+                        {
+                            "name": "mixedContentIssueDetails",
+                            "optional": true,
+                            "$ref": "MixedContentIssueDetails"
+                        },
+                        {
+                            "name": "blockedByResponseIssueDetails",
+                            "optional": true,
+                            "$ref": "BlockedByResponseIssueDetails"
+                        }
+                    ]
+                },
+                {
+                    "id": "InspectorIssue",
+                    "description": "An inspector issue reported from the back-end.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "code",
+                            "$ref": "InspectorIssueCode"
+                        },
+                        {
+                            "name": "details",
+                            "$ref": "InspectorIssueDetails"
+                        }
+                    ]
+                }
+            ],
             "commands": [
                 {
                     "name": "getEncodedResponse",
@@ -965,6 +1252,25 @@
                             "name": "encodedSize",
                             "description": "Size after re-encoding.",
                             "type": "integer"
+                        }
+                    ]
+                },
+                {
+                    "name": "disable",
+                    "description": "Disables issues domain, prevents further issues from being reported to the client."
+                },
+                {
+                    "name": "enable",
+                    "description": "Enables issues domain, sends the issues collected so far to the client by means of the\n`issueAdded` event."
+                }
+            ],
+            "events": [
+                {
+                    "name": "issueAdded",
+                    "parameters": [
+                        {
+                            "name": "issue",
+                            "$ref": "InspectorIssue"
                         }
                     ]
                 }
@@ -1126,6 +1432,11 @@
             "description": "The Browser domain defines methods and events for browser managing.",
             "types": [
                 {
+                    "id": "BrowserContextID",
+                    "experimental": true,
+                    "type": "string"
+                },
+                {
                     "id": "WindowID",
                     "experimental": true,
                     "type": "integer"
@@ -1189,13 +1500,14 @@
                         "audioCapture",
                         "backgroundSync",
                         "backgroundFetch",
-                        "clipboardRead",
-                        "clipboardWrite",
+                        "clipboardReadWrite",
+                        "clipboardSanitizedWrite",
                         "durableStorage",
                         "flash",
                         "geolocation",
                         "midi",
                         "midiSysex",
+                        "nfc",
                         "notifications",
                         "paymentHandler",
                         "periodicBackgroundSync",
@@ -1245,6 +1557,12 @@
                             "description": "For \"wake-lock\" permission, must specify type as either \"screen\" or \"system\".",
                             "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "allowWithoutSanitization",
+                            "description": "For \"clipboard\" permission, may specify allowWithoutSanitization.",
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ]
                 },
@@ -1310,11 +1628,6 @@
                     "experimental": true,
                     "parameters": [
                         {
-                            "name": "origin",
-                            "description": "Origin the permission applies to.",
-                            "type": "string"
-                        },
-                        {
                             "name": "permission",
                             "description": "Descriptor of permission to override.",
                             "$ref": "PermissionDescriptor"
@@ -1325,10 +1638,16 @@
                             "$ref": "PermissionSetting"
                         },
                         {
+                            "name": "origin",
+                            "description": "Origin the permission applies to, all origins if not specified.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
                             "name": "browserContextId",
                             "description": "Context to override. When omitted, default browser context is used.",
                             "optional": true,
-                            "$ref": "Target.TargetID"
+                            "$ref": "BrowserContextID"
                         }
                     ]
                 },
@@ -1338,10 +1657,6 @@
                     "experimental": true,
                     "parameters": [
                         {
-                            "name": "origin",
-                            "type": "string"
-                        },
-                        {
                             "name": "permissions",
                             "type": "array",
                             "items": {
@@ -1349,10 +1664,16 @@
                             }
                         },
                         {
+                            "name": "origin",
+                            "description": "Origin the permission applies to, all origins if not specified.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
                             "name": "browserContextId",
                             "description": "BrowserContext to override permissions. When omitted, default browser context is used.",
                             "optional": true,
-                            "$ref": "Target.BrowserContextID"
+                            "$ref": "BrowserContextID"
                         }
                     ]
                 },
@@ -1365,7 +1686,37 @@
                             "name": "browserContextId",
                             "description": "BrowserContext to reset permissions. When omitted, default browser context is used.",
                             "optional": true,
-                            "$ref": "Target.BrowserContextID"
+                            "$ref": "BrowserContextID"
+                        }
+                    ]
+                },
+                {
+                    "name": "setDownloadBehavior",
+                    "description": "Set the behavior when downloading a file.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "behavior",
+                            "description": "Whether to allow all or deny all download requests, or use default Chrome behavior if\navailable (otherwise deny). |allowAndName| allows download and names files according to\ntheir dowmload guids.",
+                            "type": "string",
+                            "enum": [
+                                "deny",
+                                "allow",
+                                "allowAndName",
+                                "default"
+                            ]
+                        },
+                        {
+                            "name": "browserContextId",
+                            "description": "BrowserContext to set download behavior. When omitted, default browser context is used.",
+                            "optional": true,
+                            "$ref": "BrowserContextID"
+                        },
+                        {
+                            "name": "downloadPath",
+                            "description": "The default path to save downloaded files to. This is requred if behavior is set to 'allow'\nor 'allowAndName'.",
+                            "optional": true,
+                            "type": "string"
                         }
                     ]
                 },
@@ -1569,7 +1920,8 @@
             "description": "This domain exposes CSS read/write operations. All CSS objects (stylesheets, rules, and styles)\nhave an associated `id` used in subsequent operations on the related object. Each object type has\na specific `id` structure, and those are not interchangeable between objects of different kinds.\nCSS objects can be loaded using the `get*ForNode()` calls (which accept a DOM node id). A client\ncan also keep track of stylesheets via the `styleSheetAdded`/`styleSheetRemoved` events and\nsubsequently load the required stylesheet contents using the `getStyleSheet[Text]()` methods.",
             "experimental": true,
             "dependencies": [
-                "DOM"
+                "DOM",
+                "Page"
             ],
             "types": [
                 {
@@ -1757,6 +2109,16 @@
                         {
                             "name": "length",
                             "description": "Size of the content (in characters).",
+                            "type": "number"
+                        },
+                        {
+                            "name": "endLine",
+                            "description": "Line offset of the end of the stylesheet within the resource (zero based).",
+                            "type": "number"
+                        },
+                        {
+                            "name": "endColumn",
+                            "description": "Column offset of the end of the stylesheet within the resource (zero based).",
                             "type": "number"
                         }
                     ]
@@ -2675,6 +3037,11 @@
                             "items": {
                                 "$ref": "RuleUsage"
                             }
+                        },
+                        {
+                            "name": "timestamp",
+                            "description": "Monotonically increasing time, in seconds.",
+                            "type": "number"
                         }
                     ]
                 }
@@ -2946,11 +3313,13 @@
                         {
                             "name": "skipCount",
                             "description": "Number of records to skip.",
+                            "optional": true,
                             "type": "integer"
                         },
                         {
                             "name": "pageSize",
                             "description": "Number of records to fetch.",
+                            "optional": true,
                             "type": "integer"
                         },
                         {
@@ -3124,6 +3493,7 @@
                         "first-letter",
                         "before",
                         "after",
+                        "marker",
                         "backdrop",
                         "selection",
                         "first-line-inherited",
@@ -3563,6 +3933,37 @@
                     ]
                 },
                 {
+                    "name": "scrollIntoViewIfNeeded",
+                    "description": "Scrolls the specified rect of the given node into view if not already visible.\nNote: exactly one between nodeId, backendNodeId and objectId should be passed\nto identify the node.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "nodeId",
+                            "description": "Identifier of the node.",
+                            "optional": true,
+                            "$ref": "NodeId"
+                        },
+                        {
+                            "name": "backendNodeId",
+                            "description": "Identifier of the backend node.",
+                            "optional": true,
+                            "$ref": "BackendNodeId"
+                        },
+                        {
+                            "name": "objectId",
+                            "description": "JavaScript object id of the node wrapper.",
+                            "optional": true,
+                            "$ref": "Runtime.RemoteObjectId"
+                        },
+                        {
+                            "name": "rect",
+                            "description": "The rect to be scrolled into view, relative to the node's border box, in CSS pixels.\nWhen omitted, center of the node will be used, similar to Element.scrollIntoView.",
+                            "optional": true,
+                            "$ref": "Rect"
+                        }
+                    ]
+                },
+                {
                     "name": "disable",
                     "description": "Disables DOM agent for the given page."
                 },
@@ -3749,7 +4150,6 @@
                 {
                     "name": "getNodeForLocation",
                     "description": "Returns node id at given location. Depending on whether DOM domain is enabled, nodeId is\neither returned or not.",
-                    "experimental": true,
                     "parameters": [
                         {
                             "name": "x",
@@ -3766,6 +4166,12 @@
                             "description": "False to skip to the nearest non-UA shadow root ancestor (default: false).",
                             "optional": true,
                             "type": "boolean"
+                        },
+                        {
+                            "name": "ignorePointerEventsNone",
+                            "description": "Whether to ignore pointer-events: none on elements and hit test them.",
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ],
                     "returns": [
@@ -3773,6 +4179,11 @@
                             "name": "backendNodeId",
                             "description": "Resulting node.",
                             "$ref": "BackendNodeId"
+                        },
+                        {
+                            "name": "frameId",
+                            "description": "Frame this node belongs to.",
+                            "$ref": "Page.FrameId"
                         },
                         {
                             "name": "nodeId",
@@ -5215,6 +5626,11 @@
                             "$ref": "StringIndex"
                         },
                         {
+                            "name": "title",
+                            "description": "Document title.",
+                            "$ref": "StringIndex"
+                        },
+                        {
                             "name": "baseURL",
                             "description": "Base URL that `Document` or `FrameOwner` node uses for URL completion.",
                             "$ref": "StringIndex"
@@ -5268,6 +5684,18 @@
                         {
                             "name": "scrollOffsetY",
                             "description": "Vertical scroll offset.",
+                            "optional": true,
+                            "type": "number"
+                        },
+                        {
+                            "name": "contentWidth",
+                            "description": "Document content width.",
+                            "optional": true,
+                            "type": "number"
+                        },
+                        {
+                            "name": "contentHeight",
+                            "description": "Document content height.",
                             "optional": true,
                             "type": "number"
                         }
@@ -5977,6 +6405,20 @@
                     ]
                 },
                 {
+                    "id": "MediaFeature",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "name",
+                            "type": "string"
+                        },
+                        {
+                            "name": "value",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
                     "id": "VirtualTimePolicy",
                     "description": "advance: If the scheduler runs out of immediate work, the virtual time base may fast forward to\nallow the next delayed task (if any) to run; pause: The virtual time base may not advance;\npauseIfNetworkFetchesPending: The virtual time base may not advance if there are any pending\nresource fetches.",
                     "experimental": true,
@@ -5985,6 +6427,61 @@
                         "advance",
                         "pause",
                         "pauseIfNetworkFetchesPending"
+                    ]
+                },
+                {
+                    "id": "UserAgentBrandVersion",
+                    "description": "Used to specify User Agent Cient Hints to emulate. See https://wicg.github.io/ua-client-hints",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "brand",
+                            "type": "string"
+                        },
+                        {
+                            "name": "version",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "UserAgentMetadata",
+                    "description": "Used to specify User Agent Cient Hints to emulate. See https://wicg.github.io/ua-client-hints",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "brands",
+                            "type": "array",
+                            "items": {
+                                "$ref": "UserAgentBrandVersion"
+                            }
+                        },
+                        {
+                            "name": "fullVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "platform",
+                            "type": "string"
+                        },
+                        {
+                            "name": "platformVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "architecture",
+                            "type": "string"
+                        },
+                        {
+                            "name": "model",
+                            "type": "string"
+                        },
+                        {
+                            "name": "mobile",
+                            "type": "boolean"
+                        }
                     ]
                 }
             ],
@@ -6175,12 +6672,42 @@
                 },
                 {
                     "name": "setEmulatedMedia",
-                    "description": "Emulates the given media for CSS media queries.",
+                    "description": "Emulates the given media type or media feature for CSS media queries.",
                     "parameters": [
                         {
                             "name": "media",
                             "description": "Media type to emulate. Empty string disables the override.",
+                            "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "features",
+                            "description": "Media features to emulate.",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "MediaFeature"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "setEmulatedVisionDeficiency",
+                    "description": "Emulates the given vision deficiency.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "type",
+                            "description": "Vision deficiency to emulate.",
+                            "type": "string",
+                            "enum": [
+                                "none",
+                                "achromatopsia",
+                                "blurredVision",
+                                "deuteranopia",
+                                "protanopia",
+                                "tritanopia"
+                            ]
                         }
                     ]
                 },
@@ -6304,6 +6831,19 @@
                     ]
                 },
                 {
+                    "name": "setLocaleOverride",
+                    "description": "Overrides default host system locale with the specified one.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "locale",
+                            "description": "ICU style C locale (e.g. \"en_US\"). If not specified or empty, disables the override and\nrestores default host system locale.",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
                     "name": "setTimezoneOverride",
                     "description": "Overrides default host system timezone with the specified one.",
                     "experimental": true,
@@ -6353,6 +6893,13 @@
                             "description": "The platform navigator.platform should return.",
                             "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "userAgentMetadata",
+                            "description": "To be sent in Sec-CH-UA-* headers and returned in navigator.userAgentData",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "UserAgentMetadata"
                         }
                     ]
                 }
@@ -6454,7 +7001,8 @@
             "events": [
                 {
                     "name": "needsBeginFramesChanged",
-                    "description": "Issued when the target starts or stops needing BeginFrames.",
+                    "description": "Issued when the target starts or stops needing BeginFrames.\nDeprecated. Issue beginFrame unconditionally instead and use result from\nbeginFrame to detect whether the frames were suppressed.",
+                    "deprecated": true,
                     "parameters": [
                         {
                             "name": "needsBeginFrames",
@@ -7031,6 +7579,18 @@
                     ]
                 },
                 {
+                    "id": "MouseButton",
+                    "type": "string",
+                    "enum": [
+                        "none",
+                        "left",
+                        "middle",
+                        "right",
+                        "back",
+                        "forward"
+                    ]
+                },
+                {
                     "id": "TimeSinceEpoch",
                     "description": "UTC time in seconds, counted from January 1, 1970.",
                     "type": "number"
@@ -7185,15 +7745,7 @@
                             "name": "button",
                             "description": "Mouse button (default: \"none\").",
                             "optional": true,
-                            "type": "string",
-                            "enum": [
-                                "none",
-                                "left",
-                                "middle",
-                                "right",
-                                "back",
-                                "forward"
-                            ]
+                            "$ref": "MouseButton"
                         },
                         {
                             "name": "buttons",
@@ -7296,14 +7848,8 @@
                         },
                         {
                             "name": "button",
-                            "description": "Mouse button.",
-                            "type": "string",
-                            "enum": [
-                                "none",
-                                "left",
-                                "middle",
-                                "right"
-                            ]
+                            "description": "Mouse button. Only \"none\", \"left\", \"right\" are supported.",
+                            "$ref": "MouseButton"
                         },
                         {
                             "name": "timestamp",
@@ -7747,6 +8293,15 @@
                         {
                             "name": "compositingReasons",
                             "description": "A list of strings specifying reasons for the given layer to become composited.",
+                            "deprecated": true,
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "name": "compositingReasonIds",
+                            "description": "A list of strings specifying reason IDs for the given layer to become composited.",
                             "type": "array",
                             "items": {
                                 "type": "string"
@@ -8402,8 +8957,18 @@
                     "enum": [
                         "Strict",
                         "Lax",
-                        "Extended",
                         "None"
+                    ]
+                },
+                {
+                    "id": "CookiePriority",
+                    "description": "Represents the cookie's 'Priority' status:\nhttps://tools.ietf.org/html/draft-west-cookie-priority-00",
+                    "experimental": true,
+                    "type": "string",
+                    "enum": [
+                        "Low",
+                        "Medium",
+                        "High"
                     ]
                 },
                 {
@@ -8465,6 +9030,18 @@
                         {
                             "name": "workerReady",
                             "description": "Finished Starting ServiceWorker.",
+                            "experimental": true,
+                            "type": "number"
+                        },
+                        {
+                            "name": "workerFetchStart",
+                            "description": "Started fetch event.",
+                            "experimental": true,
+                            "type": "number"
+                        },
+                        {
+                            "name": "workerRespondWithSettled",
+                            "description": "Settled fetch event respondWith promise.",
                             "experimental": true,
                             "type": "number"
                         },
@@ -8730,7 +9307,12 @@
                         "inspector",
                         "subresource-filter",
                         "content-type",
-                        "collapsed-by-client"
+                        "collapsed-by-client",
+                        "coep-frame-resource-needs-coep-header",
+                        "coop-sandboxed-iframe-cannot-navigate-to-coop-page",
+                        "corp-not-same-origin",
+                        "corp-not-same-origin-after-defaulted-to-same-origin-by-coep",
+                        "corp-not-same-site"
                     ]
                 },
                 {
@@ -9045,6 +9627,12 @@
                             "description": "Cookie SameSite type.",
                             "optional": true,
                             "$ref": "CookieSameSite"
+                        },
+                        {
+                            "name": "priority",
+                            "description": "Cookie Priority",
+                            "experimental": true,
+                            "$ref": "CookiePriority"
                         }
                     ]
                 },
@@ -9057,7 +9645,6 @@
                         "SecureOnly",
                         "SameSiteStrict",
                         "SameSiteLax",
-                        "SameSiteExtended",
                         "SameSiteUnspecifiedTreatedAsLax",
                         "SameSiteNoneInsecure",
                         "UserPreferences",
@@ -9080,7 +9667,6 @@
                         "DomainMismatch",
                         "SameSiteStrict",
                         "SameSiteLax",
-                        "SameSiteExtended",
                         "SameSiteUnspecifiedTreatedAsLax",
                         "SameSiteNoneInsecure",
                         "UserPreferences",
@@ -9094,9 +9680,12 @@
                     "type": "object",
                     "properties": [
                         {
-                            "name": "blockedReason",
-                            "description": "The reason this cookie was blocked.",
-                            "$ref": "SetCookieBlockedReason"
+                            "name": "blockedReasons",
+                            "description": "The reason(s) this cookie was blocked.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "SetCookieBlockedReason"
+                            }
                         },
                         {
                             "name": "cookieLine",
@@ -9118,9 +9707,12 @@
                     "type": "object",
                     "properties": [
                         {
-                            "name": "blockedReason",
-                            "description": "The reason the cookie was blocked.",
-                            "$ref": "CookieBlockedReason"
+                            "name": "blockedReasons",
+                            "description": "The reason(s) the cookie was blocked.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "CookieBlockedReason"
+                            }
                         },
                         {
                             "name": "cookie",
@@ -9185,6 +9777,13 @@
                             "description": "Cookie expiration date, session cookie if not set",
                             "optional": true,
                             "$ref": "TimeSinceEpoch"
+                        },
+                        {
+                            "name": "priority",
+                            "description": "Cookie Priority.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "CookiePriority"
                         }
                     ]
                 },
@@ -9932,6 +10531,13 @@
                             "description": "Cookie expiration date, session cookie if not set",
                             "optional": true,
                             "$ref": "TimeSinceEpoch"
+                        },
+                        {
+                            "name": "priority",
+                            "description": "Cookie Priority type.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "CookiePriority"
                         }
                     ],
                     "returns": [
@@ -10021,6 +10627,13 @@
                             "description": "The platform navigator.platform should return.",
                             "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "userAgentMetadata",
+                            "description": "To be sent in Sec-CH-UA-* headers and returned in navigator.userAgentData",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "Emulation.UserAgentMetadata"
                         }
                     ]
                 }
@@ -10533,8 +11146,8 @@
                             "$ref": "RequestId"
                         },
                         {
-                            "name": "blockedCookies",
-                            "description": "A list of cookies which will not be sent with this request along with corresponding reasons\nfor blocking.",
+                            "name": "associatedCookies",
+                            "description": "A list of cookies potentially associated to the requested URL. This includes both cookies sent with\nthe request and the ones not sent; the latter are distinguished by having blockedReason field set.",
                             "type": "array",
                             "items": {
                                 "$ref": "BlockedCookieWithReason"
@@ -10590,6 +11203,67 @@
                 "Runtime"
             ],
             "types": [
+                {
+                    "id": "GridHighlightConfig",
+                    "description": "Configuration data for the highlighting of Grid elements.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "showGridExtensionLines",
+                            "description": "Whether the extension lines from grid cells to the rulers should be shown (default: false).",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "gridBorderColor",
+                            "description": "The grid container border highlight color (default: transparent).",
+                            "optional": true,
+                            "$ref": "DOM.RGBA"
+                        },
+                        {
+                            "name": "cellBorderColor",
+                            "description": "The cell border color (default: transparent).",
+                            "optional": true,
+                            "$ref": "DOM.RGBA"
+                        },
+                        {
+                            "name": "gridBorderDash",
+                            "description": "Whether the grid border is dashed (default: false).",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "cellBorderDash",
+                            "description": "Whether the cell border is dashed (default: false).",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "rowGapColor",
+                            "description": "The row gap highlight fill color (default: transparent).",
+                            "optional": true,
+                            "$ref": "DOM.RGBA"
+                        },
+                        {
+                            "name": "rowHatchColor",
+                            "description": "The row gap hatching fill color (default: transparent).",
+                            "optional": true,
+                            "$ref": "DOM.RGBA"
+                        },
+                        {
+                            "name": "columnGapColor",
+                            "description": "The column gap highlight fill color (default: transparent).",
+                            "optional": true,
+                            "$ref": "DOM.RGBA"
+                        },
+                        {
+                            "name": "columnHatchColor",
+                            "description": "The column gap hatching fill color (default: transparent).",
+                            "optional": true,
+                            "$ref": "DOM.RGBA"
+                        }
+                    ]
+                },
                 {
                     "id": "HighlightConfig",
                     "description": "Configuration data for the highlighting of page elements.",
@@ -10666,6 +11340,51 @@
                             "description": "The grid layout color (default: transparent).",
                             "optional": true,
                             "$ref": "DOM.RGBA"
+                        },
+                        {
+                            "name": "colorFormat",
+                            "description": "The color format used to format color styles (default: hex).",
+                            "optional": true,
+                            "$ref": "ColorFormat"
+                        },
+                        {
+                            "name": "gridHighlightConfig",
+                            "description": "The grid layout highlight configuration (default: all transparent).",
+                            "optional": true,
+                            "$ref": "GridHighlightConfig"
+                        }
+                    ]
+                },
+                {
+                    "id": "ColorFormat",
+                    "type": "string",
+                    "enum": [
+                        "rgb",
+                        "hsl",
+                        "hex"
+                    ]
+                },
+                {
+                    "id": "HingeConfig",
+                    "description": "Configuration for dual screen hinge",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "rect",
+                            "description": "A rectangle represent hinge",
+                            "$ref": "DOM.Rect"
+                        },
+                        {
+                            "name": "contentColor",
+                            "description": "The content box highlight fill color (default: a dark color).",
+                            "optional": true,
+                            "$ref": "DOM.RGBA"
+                        },
+                        {
+                            "name": "outlineColor",
+                            "description": "The content box highlight outline color (default: transparent).",
+                            "optional": true,
+                            "$ref": "DOM.RGBA"
                         }
                     ]
                 },
@@ -10710,6 +11429,12 @@
                             "description": "Whether to include style info.",
                             "optional": true,
                             "type": "boolean"
+                        },
+                        {
+                            "name": "colorFormat",
+                            "description": "The color format to get config with (default: hex)",
+                            "optional": true,
+                            "$ref": "ColorFormat"
                         }
                     ],
                     "returns": [
@@ -10956,6 +11681,18 @@
                             "name": "show",
                             "description": "Whether to paint size or not.",
                             "type": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "name": "setShowHinge",
+                    "description": "Add a dual screen device hinge",
+                    "parameters": [
+                        {
+                            "name": "hingeConfig",
+                            "description": "hinge data, null means hideHinge",
+                            "optional": true,
+                            "$ref": "HingeConfig"
                         }
                     ]
                 }
@@ -11311,6 +12048,19 @@
                     ]
                 },
                 {
+                    "id": "AppManifestParsedProperties",
+                    "description": "Parsed app manifest properties.",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "scope",
+                            "description": "Computed scope value",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
                     "id": "LayoutViewport",
                     "description": "Layout viewport position and dimensions.",
                     "type": "object",
@@ -11498,7 +12248,73 @@
                         "scriptInitiated",
                         "metaTagRefresh",
                         "pageBlockInterstitial",
-                        "reload"
+                        "reload",
+                        "anchorClick"
+                    ]
+                },
+                {
+                    "id": "ClientNavigationDisposition",
+                    "experimental": true,
+                    "type": "string",
+                    "enum": [
+                        "currentTab",
+                        "newTab",
+                        "newWindow",
+                        "download"
+                    ]
+                },
+                {
+                    "id": "InstallabilityErrorArgument",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "name",
+                            "description": "Argument name (e.g. name:'minimum-icon-size-in-pixels').",
+                            "type": "string"
+                        },
+                        {
+                            "name": "value",
+                            "description": "Argument value (e.g. value:'64').",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "InstallabilityError",
+                    "description": "The installability error",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "errorId",
+                            "description": "The error id (e.g. 'manifest-missing-suitable-icon').",
+                            "type": "string"
+                        },
+                        {
+                            "name": "errorArguments",
+                            "description": "The list of error arguments (e.g. {name:'minimum-icon-size-in-pixels', value:'64'}).",
+                            "type": "array",
+                            "items": {
+                                "$ref": "InstallabilityErrorArgument"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "ReferrerPolicy",
+                    "description": "The referring-policy used for the navigation.",
+                    "experimental": true,
+                    "type": "string",
+                    "enum": [
+                        "noReferrer",
+                        "noReferrerWhenDowngrade",
+                        "origin",
+                        "originWhenCrossOrigin",
+                        "sameOrigin",
+                        "strictOrigin",
+                        "strictOriginWhenCrossOrigin",
+                        "unsafeUrl"
                     ]
                 }
             ],
@@ -11712,6 +12528,13 @@
                             "description": "Manifest content.",
                             "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "parsed",
+                            "description": "Parsed manifest properties",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "AppManifestParsedProperties"
                         }
                     ]
                 },
@@ -11720,11 +12543,22 @@
                     "experimental": true,
                     "returns": [
                         {
-                            "name": "errors",
+                            "name": "installabilityErrors",
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "$ref": "InstallabilityError"
                             }
+                        }
+                    ]
+                },
+                {
+                    "name": "getManifestIcons",
+                    "experimental": true,
+                    "returns": [
+                        {
+                            "name": "primaryIcon",
+                            "optional": true,
+                            "type": "string"
                         }
                     ]
                 },
@@ -11884,6 +12718,13 @@
                             "description": "Frame id to navigate, if not specified navigates the top frame.",
                             "optional": true,
                             "$ref": "FrameId"
+                        },
+                        {
+                            "name": "referrerPolicy",
+                            "description": "Referrer-policy used for the navigation.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "ReferrerPolicy"
                         }
                     ],
                     "returns": [
@@ -12303,6 +13144,7 @@
                     "name": "setDownloadBehavior",
                     "description": "Set the behavior when downloading a file.",
                     "experimental": true,
+                    "deprecated": true,
                     "parameters": [
                         {
                             "name": "behavior",
@@ -12517,37 +13359,12 @@
                 },
                 {
                     "name": "setInterceptFileChooserDialog",
-                    "description": "Intercept file chooser requests and transfer control to protocol clients.\nWhen file chooser interception is enabled, native file chooser dialog is not shown.\nInstead, a protocol event `Page.fileChooserOpened` is emitted.\nFile chooser can be handled with `page.handleFileChooser` command.",
+                    "description": "Intercept file chooser requests and transfer control to protocol clients.\nWhen file chooser interception is enabled, native file chooser dialog is not shown.\nInstead, a protocol event `Page.fileChooserOpened` is emitted.",
                     "experimental": true,
                     "parameters": [
                         {
                             "name": "enabled",
                             "type": "boolean"
-                        }
-                    ]
-                },
-                {
-                    "name": "handleFileChooser",
-                    "description": "Accepts or cancels an intercepted file chooser dialog.",
-                    "experimental": true,
-                    "parameters": [
-                        {
-                            "name": "action",
-                            "type": "string",
-                            "enum": [
-                                "accept",
-                                "cancel",
-                                "fallback"
-                            ]
-                        },
-                        {
-                            "name": "files",
-                            "description": "Array of absolute file paths to set, only respected with `accept` action.",
-                            "optional": true,
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
                         }
                     ]
                 }
@@ -12567,7 +13384,20 @@
                     "description": "Emitted only when `page.interceptFileChooser` is enabled.",
                     "parameters": [
                         {
+                            "name": "frameId",
+                            "description": "Id of the frame containing input node.",
+                            "experimental": true,
+                            "$ref": "FrameId"
+                        },
+                        {
+                            "name": "backendNodeId",
+                            "description": "Input node id.",
+                            "experimental": true,
+                            "$ref": "DOM.BackendNodeId"
+                        },
+                        {
                             "name": "mode",
+                            "description": "Input mode.",
                             "type": "string",
                             "enum": [
                                 "selectSingle",
@@ -12655,6 +13485,11 @@
                             "name": "url",
                             "description": "The destination URL for the requested navigation.",
                             "type": "string"
+                        },
+                        {
+                            "name": "disposition",
+                            "description": "The disposition for the navigation.",
+                            "$ref": "ClientNavigationDisposition"
                         }
                     ]
                 },
@@ -12676,16 +13511,7 @@
                         {
                             "name": "reason",
                             "description": "The reason for the navigation.",
-                            "type": "string",
-                            "enum": [
-                                "formSubmissionGet",
-                                "formSubmissionPost",
-                                "httpHeaderRefresh",
-                                "scriptInitiated",
-                                "metaTagRefresh",
-                                "pageBlockInterstitial",
-                                "reload"
-                            ]
+                            "$ref": "ClientNavigationReason"
                         },
                         {
                             "name": "url",
@@ -12729,9 +13555,51 @@
                             "$ref": "FrameId"
                         },
                         {
+                            "name": "guid",
+                            "description": "Global unique identifier of the download.",
+                            "type": "string"
+                        },
+                        {
                             "name": "url",
                             "description": "URL of the resource being downloaded.",
                             "type": "string"
+                        },
+                        {
+                            "name": "suggestedFilename",
+                            "description": "Suggested file name of the resource (the actual name of the file saved on disk may differ).",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "name": "downloadProgress",
+                    "description": "Fired when download makes progress. Last call has |done| == true.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "guid",
+                            "description": "Global unique identifier of the download.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "totalBytes",
+                            "description": "Total expected bytes to download.",
+                            "type": "number"
+                        },
+                        {
+                            "name": "receivedBytes",
+                            "description": "Total bytes received.",
+                            "type": "number"
+                        },
+                        {
+                            "name": "state",
+                            "description": "Download status.",
+                            "type": "string",
+                            "enum": [
+                                "inProgress",
+                                "completed",
+                                "canceled"
+                            ]
                         }
                     ]
                 },
@@ -12950,12 +13818,25 @@
                 },
                 {
                     "name": "enable",
-                    "description": "Enable collecting and reporting metrics."
+                    "description": "Enable collecting and reporting metrics.",
+                    "parameters": [
+                        {
+                            "name": "timeDomain",
+                            "description": "Time domain to use for collecting and reporting duration metrics.",
+                            "optional": true,
+                            "type": "string",
+                            "enum": [
+                                "timeTicks",
+                                "threadTicks"
+                            ]
+                        }
+                    ]
                 },
                 {
                     "name": "setTimeDomain",
                     "description": "Sets time domain to use for collecting and reporting duration metrics.\nNote that this must be called before enabling metrics collection. Calling\nthis method while metrics collection is enabled returns an error.",
                     "experimental": true,
+                    "deprecated": true,
                     "parameters": [
                         {
                             "name": "timeDomain",
@@ -13033,7 +13914,172 @@
                         "neutral",
                         "insecure",
                         "secure",
-                        "info"
+                        "info",
+                        "insecure-broken"
+                    ]
+                },
+                {
+                    "id": "CertificateSecurityState",
+                    "description": "Details about the security state of the page certificate.",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "protocol",
+                            "description": "Protocol name (e.g. \"TLS 1.2\" or \"QUIC\").",
+                            "type": "string"
+                        },
+                        {
+                            "name": "keyExchange",
+                            "description": "Key Exchange used by the connection, or the empty string if not applicable.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "keyExchangeGroup",
+                            "description": "(EC)DH group used by the connection, if applicable.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "cipher",
+                            "description": "Cipher name.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "mac",
+                            "description": "TLS MAC. Note that AEAD ciphers do not have separate MACs.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "certificate",
+                            "description": "Page certificate.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "name": "subjectName",
+                            "description": "Certificate subject name.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "issuer",
+                            "description": "Name of the issuing CA.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "validFrom",
+                            "description": "Certificate valid from date.",
+                            "$ref": "Network.TimeSinceEpoch"
+                        },
+                        {
+                            "name": "validTo",
+                            "description": "Certificate valid to (expiration) date",
+                            "$ref": "Network.TimeSinceEpoch"
+                        },
+                        {
+                            "name": "certificateNetworkError",
+                            "description": "The highest priority network error code, if the certificate has an error.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "certificateHasWeakSignature",
+                            "description": "True if the certificate uses a weak signature aglorithm.",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "certificateHasSha1Signature",
+                            "description": "True if the certificate has a SHA1 signature in the chain.",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "modernSSL",
+                            "description": "True if modern SSL",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "obsoleteSslProtocol",
+                            "description": "True if the connection is using an obsolete SSL protocol.",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "obsoleteSslKeyExchange",
+                            "description": "True if the connection is using an obsolete SSL key exchange.",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "obsoleteSslCipher",
+                            "description": "True if the connection is using an obsolete SSL cipher.",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "obsoleteSslSignature",
+                            "description": "True if the connection is using an obsolete SSL signature.",
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "id": "SafetyTipStatus",
+                    "experimental": true,
+                    "type": "string",
+                    "enum": [
+                        "badReputation",
+                        "lookalike"
+                    ]
+                },
+                {
+                    "id": "SafetyTipInfo",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "safetyTipStatus",
+                            "description": "Describes whether the page triggers any safety tips or reputation warnings. Default is unknown.",
+                            "$ref": "SafetyTipStatus"
+                        },
+                        {
+                            "name": "safeUrl",
+                            "description": "The URL the safety tip suggested (\"Did you mean?\"). Only filled in for lookalike matches.",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "VisibleSecurityState",
+                    "description": "Security state information about the page.",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "securityState",
+                            "description": "The security level of the page.",
+                            "$ref": "SecurityState"
+                        },
+                        {
+                            "name": "certificateSecurityState",
+                            "description": "Security state details about the page certificate.",
+                            "optional": true,
+                            "$ref": "CertificateSecurityState"
+                        },
+                        {
+                            "name": "safetyTipInfo",
+                            "description": "The type of Safety Tip triggered on the page. Note that this field will be set even if the Safety Tip UI was not actually shown.",
+                            "optional": true,
+                            "$ref": "SafetyTipInfo"
+                        },
+                        {
+                            "name": "securityStateIssueIds",
+                            "description": "Array of security state issues ids.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
                     ]
                 },
                 {
@@ -13213,6 +14259,18 @@
                     ]
                 },
                 {
+                    "name": "visibleSecurityStateChanged",
+                    "description": "The security state of the page changed.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "visibleSecurityState",
+                            "description": "Security state information about the page.",
+                            "$ref": "VisibleSecurityState"
+                        }
+                    ]
+                },
+                {
                     "name": "securityStateChanged",
                     "description": "The security state of the page changed.",
                     "parameters": [
@@ -13254,6 +14312,9 @@
         {
             "domain": "ServiceWorker",
             "experimental": true,
+            "dependencies": [
+                "Target"
+            ],
             "types": [
                 {
                     "id": "RegistrationID",
@@ -13552,6 +14613,10 @@
         {
             "domain": "Storage",
             "experimental": true,
+            "dependencies": [
+                "Browser",
+                "Network"
+            ],
             "types": [
                 {
                     "id": "StorageType",
@@ -13603,6 +14668,60 @@
                             "name": "storageTypes",
                             "description": "Comma separated list of StorageType to clear.",
                             "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "name": "getCookies",
+                    "description": "Returns all browser cookies.",
+                    "parameters": [
+                        {
+                            "name": "browserContextId",
+                            "description": "Browser context to use when called on the browser endpoint.",
+                            "optional": true,
+                            "$ref": "Browser.BrowserContextID"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "cookies",
+                            "description": "Array of cookie objects.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "Network.Cookie"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "setCookies",
+                    "description": "Sets given cookies.",
+                    "parameters": [
+                        {
+                            "name": "cookies",
+                            "description": "Cookies to be set.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "Network.CookieParam"
+                            }
+                        },
+                        {
+                            "name": "browserContextId",
+                            "description": "Browser context to use when called on the browser endpoint.",
+                            "optional": true,
+                            "$ref": "Browser.BrowserContextID"
+                        }
+                    ]
+                },
+                {
+                    "name": "clearCookies",
+                    "description": "Clears cookies.",
+                    "parameters": [
+                        {
+                            "name": "browserContextId",
+                            "description": "Browser context to use when called on the browser endpoint.",
+                            "optional": true,
+                            "$ref": "Browser.BrowserContextID"
                         }
                     ]
                 },
@@ -13762,6 +14881,18 @@
                         {
                             "name": "deviceId",
                             "description": "PCI ID of the GPU device, if available; 0 otherwise.",
+                            "type": "number"
+                        },
+                        {
+                            "name": "subSysId",
+                            "description": "Sub sys ID of the GPU, only available on Windows.",
+                            "optional": true,
+                            "type": "number"
+                        },
+                        {
+                            "name": "revision",
+                            "description": "Revision of the GPU, only available on Windows.",
+                            "optional": true,
                             "type": "number"
                         },
                         {
@@ -14040,11 +15171,6 @@
                     "type": "string"
                 },
                 {
-                    "id": "BrowserContextID",
-                    "experimental": true,
-                    "type": "string"
-                },
-                {
                     "id": "TargetInfo",
                     "type": "object",
                     "properties": [
@@ -14079,7 +15205,7 @@
                             "name": "browserContextId",
                             "experimental": true,
                             "optional": true,
-                            "$ref": "BrowserContextID"
+                            "$ref": "Browser.BrowserContextID"
                         }
                     ]
                 },
@@ -14120,8 +15246,7 @@
                         },
                         {
                             "name": "flatten",
-                            "description": "Enables \"flat\" access to the session via specifying sessionId attribute in the commands.",
-                            "experimental": true,
+                            "description": "Enables \"flat\" access to the session via specifying sessionId attribute in the commands.\nWe plan to make this the default, deprecate non-flattened mode,\nand eventually retire it. See crbug.com/991325.",
                             "optional": true,
                             "type": "boolean"
                         }
@@ -14183,11 +15308,19 @@
                     "name": "createBrowserContext",
                     "description": "Creates a new empty BrowserContext. Similar to an incognito profile but you can have more than\none.",
                     "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "disposeOnDetach",
+                            "description": "If specified, disposes this context when debugging session disconnects.",
+                            "optional": true,
+                            "type": "boolean"
+                        }
+                    ],
                     "returns": [
                         {
                             "name": "browserContextId",
                             "description": "The id of the context created.",
-                            "$ref": "BrowserContextID"
+                            "$ref": "Browser.BrowserContextID"
                         }
                     ]
                 },
@@ -14201,7 +15334,7 @@
                             "description": "An array of browser context ids.",
                             "type": "array",
                             "items": {
-                                "$ref": "BrowserContextID"
+                                "$ref": "Browser.BrowserContextID"
                             }
                         }
                     ]
@@ -14231,7 +15364,7 @@
                             "name": "browserContextId",
                             "description": "The browser context to create the page in.",
                             "optional": true,
-                            "$ref": "BrowserContextID"
+                            "$ref": "Browser.BrowserContextID"
                         },
                         {
                             "name": "enableBeginFrameControl",
@@ -14287,7 +15420,7 @@
                     "parameters": [
                         {
                             "name": "browserContextId",
-                            "$ref": "BrowserContextID"
+                            "$ref": "Browser.BrowserContextID"
                         }
                     ]
                 },
@@ -14325,7 +15458,8 @@
                 },
                 {
                     "name": "sendMessageToTarget",
-                    "description": "Sends protocol message over session with given id.",
+                    "description": "Sends protocol message over session with given id.\nConsider using flat mode instead; see commands attachToTarget, setAutoAttach,\nand crbug.com/991325.",
+                    "deprecated": true,
                     "parameters": [
                         {
                             "name": "message",
@@ -14363,8 +15497,7 @@
                         },
                         {
                             "name": "flatten",
-                            "description": "Enables \"flat\" access to the session via specifying sessionId attribute in the commands.",
-                            "experimental": true,
+                            "description": "Enables \"flat\" access to the session via specifying sessionId attribute in the commands.\nWe plan to make this the default, deprecate non-flattened mode,\nand eventually retire it. See crbug.com/991325.",
                             "optional": true,
                             "type": "boolean"
                         }
@@ -14691,6 +15824,14 @@
                 {
                     "name": "requestMemoryDump",
                     "description": "Request a global memory dump.",
+                    "parameters": [
+                        {
+                            "name": "deterministic",
+                            "description": "Enables more deterministic results by forcing garbage collection",
+                            "optional": true,
+                            "type": "boolean"
+                        }
+                    ],
                     "returns": [
                         {
                             "name": "dumpGuid",
@@ -15014,10 +16155,17 @@
                         {
                             "name": "responseHeaders",
                             "description": "Response headers.",
+                            "optional": true,
                             "type": "array",
                             "items": {
                                 "$ref": "HeaderEntry"
                             }
+                        },
+                        {
+                            "name": "binaryResponseHeaders",
+                            "description": "Alternative way of specifying response headers as a \\0-separated\nseries of name: value pairs. Prefer the above method unless you\nneed to represent some non-UTF8 values that can't be transmitted\nover the protocol as text.",
+                            "optional": true,
+                            "type": "string"
                         },
                         {
                             "name": "body",
@@ -15027,7 +16175,7 @@
                         },
                         {
                             "name": "responsePhrase",
-                            "description": "A textual representation of responseCode.\nIf absent, a standard phrase mathcing responseCode is used.",
+                            "description": "A textual representation of responseCode.\nIf absent, a standard phrase matching responseCode is used.",
                             "optional": true,
                             "type": "string"
                         }
@@ -15062,7 +16210,7 @@
                         },
                         {
                             "name": "headers",
-                            "description": "If set, overrides the request headrts.",
+                            "description": "If set, overrides the request headers.",
                             "optional": true,
                             "type": "array",
                             "items": {
@@ -15720,15 +16868,25 @@
                         },
                         {
                             "name": "hasResidentKey",
+                            "description": "Defaults to false.",
+                            "optional": true,
                             "type": "boolean"
                         },
                         {
                             "name": "hasUserVerification",
+                            "description": "Defaults to false.",
+                            "optional": true,
                             "type": "boolean"
                         },
                         {
                             "name": "automaticPresenceSimulation",
                             "description": "If set to true, tests of user presence will succeed immediately.\nOtherwise, they will not be resolved. Defaults to true.",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "isUserVerified",
+                            "description": "Sets whether User Verification succeeds or fails for an authenticator.\nDefaults to false.",
                             "optional": true,
                             "type": "boolean"
                         }
@@ -15914,50 +17072,73 @@
                     "type": "number"
                 },
                 {
-                    "id": "PlayerProperty",
-                    "description": "Player Property type",
+                    "id": "PlayerMessage",
+                    "description": "Have one type per entry in MediaLogRecord::Type\nCorresponds to kMessage",
                     "type": "object",
                     "properties": [
                         {
-                            "name": "name",
-                            "type": "string"
+                            "name": "level",
+                            "description": "Keep in sync with MediaLogMessageLevel\nWe are currently keeping the message level 'error' separate from the\nPlayerError type because right now they represent different things,\nthis one being a DVLOG(ERROR) style log message that gets printed\nbased on what log level is selected in the UI, and the other is a\nrepresentation of a media::PipelineStatus object. Soon however we're\ngoing to be moving away from using PipelineStatus for errors and\nintroducing a new error type which should hopefully let us integrate\nthe error log level into the PlayerError type.",
+                            "type": "string",
+                            "enum": [
+                                "error",
+                                "warning",
+                                "info",
+                                "debug"
+                            ]
                         },
                         {
-                            "name": "value",
-                            "optional": true,
+                            "name": "message",
                             "type": "string"
                         }
                     ]
                 },
                 {
-                    "id": "PlayerEventType",
-                    "description": "Break out events into different types",
-                    "type": "string",
-                    "enum": [
-                        "playbackEvent",
-                        "systemEvent",
-                        "messageEvent"
-                    ]
-                },
-                {
-                    "id": "PlayerEvent",
+                    "id": "PlayerProperty",
+                    "description": "Corresponds to kMediaPropertyChange",
                     "type": "object",
                     "properties": [
-                        {
-                            "name": "type",
-                            "$ref": "PlayerEventType"
-                        },
-                        {
-                            "name": "timestamp",
-                            "description": "Events are timestamped relative to the start of the player creation\nnot relative to the start of playback.",
-                            "$ref": "Timestamp"
-                        },
                         {
                             "name": "name",
                             "type": "string"
                         },
                         {
                             "name": "value",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "PlayerEvent",
+                    "description": "Corresponds to kMediaEventTriggered",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "timestamp",
+                            "$ref": "Timestamp"
+                        },
+                        {
+                            "name": "value",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "PlayerError",
+                    "description": "Corresponds to kMediaError",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "type",
+                            "type": "string",
+                            "enum": [
+                                "pipeline_error",
+                                "media_error"
+                            ]
+                        },
+                        {
+                            "name": "errorCode",
+                            "description": "When this switches to using media::Status instead of PipelineStatus\nwe can remove \"errorCode\" and replace it with the fields from\na Status instance. This also seems like a duplicate of the error\nlevel enum - there is a todo bug to have that level removed and\nuse this instead. (crbug.com/1068454)",
                             "type": "string"
                         }
                     ]
@@ -15994,6 +17175,40 @@
                             "type": "array",
                             "items": {
                                 "$ref": "PlayerEvent"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "playerMessagesLogged",
+                    "description": "Send a list of any messages that need to be delivered.",
+                    "parameters": [
+                        {
+                            "name": "playerId",
+                            "$ref": "PlayerId"
+                        },
+                        {
+                            "name": "messages",
+                            "type": "array",
+                            "items": {
+                                "$ref": "PlayerMessage"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "playerErrorsRaised",
+                    "description": "Send a list of any errors that need to be delivered.",
+                    "parameters": [
+                        {
+                            "name": "playerId",
+                            "$ref": "PlayerId"
+                        },
+                        {
+                            "name": "errors",
+                            "type": "array",
+                            "items": {
+                                "$ref": "PlayerError"
                             }
                         }
                     ]

--- a/cdt-protocol-parser/src/test/resources/js_protocol.json
+++ b/cdt-protocol-parser/src/test/resources/js_protocol.json
@@ -227,7 +227,8 @@
                                 "block",
                                 "script",
                                 "eval",
-                                "module"
+                                "module",
+                                "wasm-expression-stack"
                             ]
                         },
                         {
@@ -300,6 +301,39 @@
                                 "call",
                                 "return"
                             ]
+                        }
+                    ]
+                },
+                {
+                    "id": "ScriptLanguage",
+                    "description": "Enum of possible script languages.",
+                    "type": "string",
+                    "enum": [
+                        "JavaScript",
+                        "WebAssembly"
+                    ]
+                },
+                {
+                    "id": "DebugSymbols",
+                    "description": "Debug symbols available for a wasm script.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "type",
+                            "description": "Type of the debug symbols.",
+                            "type": "string",
+                            "enum": [
+                                "None",
+                                "SourceMap",
+                                "EmbeddedDWARF",
+                                "ExternalDWARF"
+                            ]
+                        },
+                        {
+                            "name": "externalURL",
+                            "description": "URL of the external symbol source.",
+                            "optional": true,
+                            "type": "string"
                         }
                     ]
                 }
@@ -424,6 +458,43 @@
                     ]
                 },
                 {
+                    "name": "executeWasmEvaluator",
+                    "description": "Execute a Wasm Evaluator module on a given call frame.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "callFrameId",
+                            "description": "WebAssembly call frame identifier to evaluate on.",
+                            "$ref": "CallFrameId"
+                        },
+                        {
+                            "name": "evaluator",
+                            "description": "Code of the evaluator module.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "timeout",
+                            "description": "Terminate execution after timing out (number of milliseconds).",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "Runtime.TimeDelta"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "result",
+                            "description": "Object wrapper for the evaluation result.",
+                            "$ref": "Runtime.RemoteObject"
+                        },
+                        {
+                            "name": "exceptionDetails",
+                            "description": "Exception details.",
+                            "optional": true,
+                            "$ref": "Runtime.ExceptionDetails"
+                        }
+                    ]
+                },
+                {
                     "name": "getPossibleBreakpoints",
                     "description": "Returns possible locations for breakpoint. scriptId in start and end range locations should be\nthe same.",
                     "parameters": [
@@ -469,6 +540,31 @@
                     "returns": [
                         {
                             "name": "scriptSource",
+                            "description": "Script source (empty in case of Wasm bytecode).",
+                            "type": "string"
+                        },
+                        {
+                            "name": "bytecode",
+                            "description": "Wasm bytecode.",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "name": "getWasmBytecode",
+                    "description": "This command is deprecated. Use getScriptSource instead.",
+                    "deprecated": true,
+                    "parameters": [
+                        {
+                            "name": "scriptId",
+                            "description": "Id of the Wasm script to get source for.",
+                            "$ref": "Runtime.ScriptId"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "bytecode",
                             "description": "Script source.",
                             "type": "string"
                         }
@@ -498,6 +594,7 @@
                 {
                     "name": "pauseOnAsyncCall",
                     "experimental": true,
+                    "deprecated": true,
                     "parameters": [
                         {
                             "name": "parentStackTraceId",
@@ -552,7 +649,15 @@
                 },
                 {
                     "name": "resume",
-                    "description": "Resumes JavaScript execution."
+                    "description": "Resumes JavaScript execution.",
+                    "parameters": [
+                        {
+                            "name": "terminateOnResume",
+                            "description": "Set to true to terminate execution upon resuming execution. In contrast\nto Runtime.terminateExecution, this will allows to execute further\nJavaScript (i.e. via evaluation) until execution of the paused code\nis actually resumed, at which point termination is triggered.\nIf execution is currently not paused, this parameter has no effect.",
+                            "optional": true,
+                            "type": "boolean"
+                        }
+                    ]
                 },
                 {
                     "name": "searchInContent",
@@ -909,7 +1014,7 @@
                     "parameters": [
                         {
                             "name": "breakOnAsyncCall",
-                            "description": "Debugger will issue additional Debugger.paused notification if any async task is scheduled\nbefore next pause.",
+                            "description": "Debugger will pause on the execution of the first async task which was scheduled\nbefore next pause.",
                             "experimental": true,
                             "optional": true,
                             "type": "boolean"
@@ -1002,8 +1107,9 @@
                         },
                         {
                             "name": "asyncCallStackTraceId",
-                            "description": "Just scheduled async call will have this stack trace as parent stack during async execution.\nThis field is available only after `Debugger.stepInto` call with `breakOnAsynCall` flag.",
+                            "description": "Never present, will be removed.",
                             "experimental": true,
+                            "deprecated": true,
                             "optional": true,
                             "$ref": "Runtime.StackTraceId"
                         }
@@ -1093,6 +1199,20 @@
                             "experimental": true,
                             "optional": true,
                             "$ref": "Runtime.StackTrace"
+                        },
+                        {
+                            "name": "codeOffset",
+                            "description": "If the scriptLanguage is WebAssembly, the code section offset in the module.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "integer"
+                        },
+                        {
+                            "name": "scriptLanguage",
+                            "description": "The language of the script.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "Debugger.ScriptLanguage"
                         }
                     ]
                 },
@@ -1183,6 +1303,27 @@
                             "experimental": true,
                             "optional": true,
                             "$ref": "Runtime.StackTrace"
+                        },
+                        {
+                            "name": "codeOffset",
+                            "description": "If the scriptLanguage is WebAssembly, the code section offset in the module.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "integer"
+                        },
+                        {
+                            "name": "scriptLanguage",
+                            "description": "The language of the script.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "Debugger.ScriptLanguage"
+                        },
+                        {
+                            "name": "debugSymbols",
+                            "description": "If the scriptLanguage is WebASsembly, the source of debug symbols for the module.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "Debugger.DebugSymbols"
                         }
                     ]
                 }
@@ -1380,6 +1521,11 @@
                             "description": "If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken\nwhen the tracking is stopped.",
                             "optional": true,
                             "type": "boolean"
+                        },
+                        {
+                            "name": "treatGlobalObjectsAsRoots",
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ]
                 },
@@ -1389,6 +1535,12 @@
                         {
                             "name": "reportProgress",
                             "description": "If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken.",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "treatGlobalObjectsAsRoots",
+                            "description": "If true, a raw snapshot without artifical roots will be generated",
                             "optional": true,
                             "type": "boolean"
                         }
@@ -1701,6 +1853,24 @@
                             }
                         }
                     ]
+                },
+                {
+                    "id": "CounterInfo",
+                    "description": "Collected counter information.",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "name",
+                            "description": "Counter name.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "value",
+                            "description": "Counter value.",
+                            "type": "integer"
+                        }
+                    ]
                 }
             ],
             "commands": [
@@ -1753,6 +1923,19 @@
                             "description": "Collect block-based coverage.",
                             "optional": true,
                             "type": "boolean"
+                        },
+                        {
+                            "name": "allowTriggeredUpdates",
+                            "description": "Allow the backend to send updates on its own initiative",
+                            "optional": true,
+                            "type": "boolean"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "timestamp",
+                            "description": "Monotonically increasing time (in seconds) when the coverage update was taken in the backend.",
+                            "type": "number"
                         }
                     ]
                 },
@@ -1791,6 +1974,11 @@
                             "items": {
                                 "$ref": "ScriptCoverage"
                             }
+                        },
+                        {
+                            "name": "timestamp",
+                            "description": "Monotonically increasing time (in seconds) when the coverage update was taken in the backend.",
+                            "type": "number"
                         }
                     ]
                 },
@@ -1805,6 +1993,31 @@
                             "type": "array",
                             "items": {
                                 "$ref": "ScriptTypeProfile"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "enableRuntimeCallStats",
+                    "description": "Enable run time call stats collection.",
+                    "experimental": true
+                },
+                {
+                    "name": "disableRuntimeCallStats",
+                    "description": "Disable run time call stats collection.",
+                    "experimental": true
+                },
+                {
+                    "name": "getRuntimeCallStats",
+                    "description": "Retrieve run time call stats.",
+                    "experimental": true,
+                    "returns": [
+                        {
+                            "name": "result",
+                            "description": "Collected counter information.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "CounterInfo"
                             }
                         }
                     ]
@@ -1855,6 +2068,31 @@
                             "type": "string"
                         }
                     ]
+                },
+                {
+                    "name": "preciseCoverageDeltaUpdate",
+                    "description": "Reports coverage delta since the last poll (either from an event like this, or from\n`takePreciseCoverage` for the current isolate. May only be sent if precise code\ncoverage has been started. This event can be trigged by the embedder to, for example,\ntrigger collection of coverage data immediatelly at a certain point in time.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "timestamp",
+                            "description": "Monotonically increasing time (in seconds) when the coverage update was taken in the backend.",
+                            "type": "number"
+                        },
+                        {
+                            "name": "occassion",
+                            "description": "Identifier for distinguishing coverage events.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "result",
+                            "description": "Coverage data for the current isolate.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "ScriptCoverage"
+                            }
+                        }
+                    ]
                 }
             ]
         },
@@ -1894,12 +2132,13 @@
                                 "number",
                                 "boolean",
                                 "symbol",
-                                "bigint"
+                                "bigint",
+                                "wasm"
                             ]
                         },
                         {
                             "name": "subtype",
-                            "description": "Object subtype hint. Specified for `object` type values only.",
+                            "description": "Object subtype hint. Specified for `object` or `wasm` type values only.",
                             "optional": true,
                             "type": "string",
                             "enum": [
@@ -1919,7 +2158,13 @@
                                 "promise",
                                 "typedarray",
                                 "arraybuffer",
-                                "dataview"
+                                "dataview",
+                                "i32",
+                                "i64",
+                                "f32",
+                                "f64",
+                                "v128",
+                                "anyref"
                             ]
                         },
                         {
@@ -2230,6 +2475,19 @@
                         {
                             "name": "value",
                             "description": "The value associated with the private property.",
+                            "optional": true,
+                            "$ref": "RemoteObject"
+                        },
+                        {
+                            "name": "get",
+                            "description": "A function which serves as a getter for the private property,\nor `undefined` if there is no getter (accessor descriptors only).",
+                            "optional": true,
+                            "$ref": "RemoteObject"
+                        },
+                        {
+                            "name": "set",
+                            "description": "A function which serves as a setter for the private property,\nor `undefined` if there is no setter (accessor descriptors only).",
+                            "optional": true,
                             "$ref": "RemoteObject"
                         }
                     ]
@@ -2681,7 +2939,7 @@
                         },
                         {
                             "name": "throwOnSideEffect",
-                            "description": "Whether to throw an exception if side effect cannot be ruled out during evaluation.",
+                            "description": "Whether to throw an exception if side effect cannot be ruled out during evaluation.\nThis implies `disableBreaks` below.",
                             "experimental": true,
                             "optional": true,
                             "type": "boolean"
@@ -2692,6 +2950,20 @@
                             "experimental": true,
                             "optional": true,
                             "$ref": "TimeDelta"
+                        },
+                        {
+                            "name": "disableBreaks",
+                            "description": "Disable breakpoints during execution.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "replMode",
+                            "description": "Setting this flag to true enables `let` re-declaration and top-level `await`.\nNote that `let` variables can only be re-declared if they originate from\n`replMode` themselves.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ],
                     "returns": [

--- a/js_protocol.json
+++ b/js_protocol.json
@@ -227,7 +227,8 @@
                                 "block",
                                 "script",
                                 "eval",
-                                "module"
+                                "module",
+                                "wasm-expression-stack"
                             ]
                         },
                         {
@@ -300,6 +301,39 @@
                                 "call",
                                 "return"
                             ]
+                        }
+                    ]
+                },
+                {
+                    "id": "ScriptLanguage",
+                    "description": "Enum of possible script languages.",
+                    "type": "string",
+                    "enum": [
+                        "JavaScript",
+                        "WebAssembly"
+                    ]
+                },
+                {
+                    "id": "DebugSymbols",
+                    "description": "Debug symbols available for a wasm script.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "type",
+                            "description": "Type of the debug symbols.",
+                            "type": "string",
+                            "enum": [
+                                "None",
+                                "SourceMap",
+                                "EmbeddedDWARF",
+                                "ExternalDWARF"
+                            ]
+                        },
+                        {
+                            "name": "externalURL",
+                            "description": "URL of the external symbol source.",
+                            "optional": true,
+                            "type": "string"
                         }
                     ]
                 }
@@ -424,6 +458,43 @@
                     ]
                 },
                 {
+                    "name": "executeWasmEvaluator",
+                    "description": "Execute a Wasm Evaluator module on a given call frame.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "callFrameId",
+                            "description": "WebAssembly call frame identifier to evaluate on.",
+                            "$ref": "CallFrameId"
+                        },
+                        {
+                            "name": "evaluator",
+                            "description": "Code of the evaluator module.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "timeout",
+                            "description": "Terminate execution after timing out (number of milliseconds).",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "Runtime.TimeDelta"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "result",
+                            "description": "Object wrapper for the evaluation result.",
+                            "$ref": "Runtime.RemoteObject"
+                        },
+                        {
+                            "name": "exceptionDetails",
+                            "description": "Exception details.",
+                            "optional": true,
+                            "$ref": "Runtime.ExceptionDetails"
+                        }
+                    ]
+                },
+                {
                     "name": "getPossibleBreakpoints",
                     "description": "Returns possible locations for breakpoint. scriptId in start and end range locations should be\nthe same.",
                     "parameters": [
@@ -469,6 +540,31 @@
                     "returns": [
                         {
                             "name": "scriptSource",
+                            "description": "Script source (empty in case of Wasm bytecode).",
+                            "type": "string"
+                        },
+                        {
+                            "name": "bytecode",
+                            "description": "Wasm bytecode.",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "name": "getWasmBytecode",
+                    "description": "This command is deprecated. Use getScriptSource instead.",
+                    "deprecated": true,
+                    "parameters": [
+                        {
+                            "name": "scriptId",
+                            "description": "Id of the Wasm script to get source for.",
+                            "$ref": "Runtime.ScriptId"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "bytecode",
                             "description": "Script source.",
                             "type": "string"
                         }
@@ -498,6 +594,7 @@
                 {
                     "name": "pauseOnAsyncCall",
                     "experimental": true,
+                    "deprecated": true,
                     "parameters": [
                         {
                             "name": "parentStackTraceId",
@@ -552,7 +649,15 @@
                 },
                 {
                     "name": "resume",
-                    "description": "Resumes JavaScript execution."
+                    "description": "Resumes JavaScript execution.",
+                    "parameters": [
+                        {
+                            "name": "terminateOnResume",
+                            "description": "Set to true to terminate execution upon resuming execution. In contrast\nto Runtime.terminateExecution, this will allows to execute further\nJavaScript (i.e. via evaluation) until execution of the paused code\nis actually resumed, at which point termination is triggered.\nIf execution is currently not paused, this parameter has no effect.",
+                            "optional": true,
+                            "type": "boolean"
+                        }
+                    ]
                 },
                 {
                     "name": "searchInContent",
@@ -909,7 +1014,7 @@
                     "parameters": [
                         {
                             "name": "breakOnAsyncCall",
-                            "description": "Debugger will issue additional Debugger.paused notification if any async task is scheduled\nbefore next pause.",
+                            "description": "Debugger will pause on the execution of the first async task which was scheduled\nbefore next pause.",
                             "experimental": true,
                             "optional": true,
                             "type": "boolean"
@@ -1002,8 +1107,9 @@
                         },
                         {
                             "name": "asyncCallStackTraceId",
-                            "description": "Just scheduled async call will have this stack trace as parent stack during async execution.\nThis field is available only after `Debugger.stepInto` call with `breakOnAsynCall` flag.",
+                            "description": "Never present, will be removed.",
                             "experimental": true,
+                            "deprecated": true,
                             "optional": true,
                             "$ref": "Runtime.StackTraceId"
                         }
@@ -1093,6 +1199,20 @@
                             "experimental": true,
                             "optional": true,
                             "$ref": "Runtime.StackTrace"
+                        },
+                        {
+                            "name": "codeOffset",
+                            "description": "If the scriptLanguage is WebAssembly, the code section offset in the module.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "integer"
+                        },
+                        {
+                            "name": "scriptLanguage",
+                            "description": "The language of the script.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "Debugger.ScriptLanguage"
                         }
                     ]
                 },
@@ -1183,6 +1303,27 @@
                             "experimental": true,
                             "optional": true,
                             "$ref": "Runtime.StackTrace"
+                        },
+                        {
+                            "name": "codeOffset",
+                            "description": "If the scriptLanguage is WebAssembly, the code section offset in the module.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "integer"
+                        },
+                        {
+                            "name": "scriptLanguage",
+                            "description": "The language of the script.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "Debugger.ScriptLanguage"
+                        },
+                        {
+                            "name": "debugSymbols",
+                            "description": "If the scriptLanguage is WebASsembly, the source of debug symbols for the module.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "Debugger.DebugSymbols"
                         }
                     ]
                 }
@@ -1380,6 +1521,11 @@
                             "description": "If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken\nwhen the tracking is stopped.",
                             "optional": true,
                             "type": "boolean"
+                        },
+                        {
+                            "name": "treatGlobalObjectsAsRoots",
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ]
                 },
@@ -1389,6 +1535,12 @@
                         {
                             "name": "reportProgress",
                             "description": "If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken.",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "treatGlobalObjectsAsRoots",
+                            "description": "If true, a raw snapshot without artifical roots will be generated",
                             "optional": true,
                             "type": "boolean"
                         }
@@ -1701,6 +1853,24 @@
                             }
                         }
                     ]
+                },
+                {
+                    "id": "CounterInfo",
+                    "description": "Collected counter information.",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "name",
+                            "description": "Counter name.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "value",
+                            "description": "Counter value.",
+                            "type": "integer"
+                        }
+                    ]
                 }
             ],
             "commands": [
@@ -1753,6 +1923,19 @@
                             "description": "Collect block-based coverage.",
                             "optional": true,
                             "type": "boolean"
+                        },
+                        {
+                            "name": "allowTriggeredUpdates",
+                            "description": "Allow the backend to send updates on its own initiative",
+                            "optional": true,
+                            "type": "boolean"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "timestamp",
+                            "description": "Monotonically increasing time (in seconds) when the coverage update was taken in the backend.",
+                            "type": "number"
                         }
                     ]
                 },
@@ -1791,6 +1974,11 @@
                             "items": {
                                 "$ref": "ScriptCoverage"
                             }
+                        },
+                        {
+                            "name": "timestamp",
+                            "description": "Monotonically increasing time (in seconds) when the coverage update was taken in the backend.",
+                            "type": "number"
                         }
                     ]
                 },
@@ -1805,6 +1993,31 @@
                             "type": "array",
                             "items": {
                                 "$ref": "ScriptTypeProfile"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "enableRuntimeCallStats",
+                    "description": "Enable run time call stats collection.",
+                    "experimental": true
+                },
+                {
+                    "name": "disableRuntimeCallStats",
+                    "description": "Disable run time call stats collection.",
+                    "experimental": true
+                },
+                {
+                    "name": "getRuntimeCallStats",
+                    "description": "Retrieve run time call stats.",
+                    "experimental": true,
+                    "returns": [
+                        {
+                            "name": "result",
+                            "description": "Collected counter information.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "CounterInfo"
                             }
                         }
                     ]
@@ -1855,6 +2068,31 @@
                             "type": "string"
                         }
                     ]
+                },
+                {
+                    "name": "preciseCoverageDeltaUpdate",
+                    "description": "Reports coverage delta since the last poll (either from an event like this, or from\n`takePreciseCoverage` for the current isolate. May only be sent if precise code\ncoverage has been started. This event can be trigged by the embedder to, for example,\ntrigger collection of coverage data immediatelly at a certain point in time.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "timestamp",
+                            "description": "Monotonically increasing time (in seconds) when the coverage update was taken in the backend.",
+                            "type": "number"
+                        },
+                        {
+                            "name": "occassion",
+                            "description": "Identifier for distinguishing coverage events.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "result",
+                            "description": "Coverage data for the current isolate.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "ScriptCoverage"
+                            }
+                        }
+                    ]
                 }
             ]
         },
@@ -1894,12 +2132,13 @@
                                 "number",
                                 "boolean",
                                 "symbol",
-                                "bigint"
+                                "bigint",
+                                "wasm"
                             ]
                         },
                         {
                             "name": "subtype",
-                            "description": "Object subtype hint. Specified for `object` type values only.",
+                            "description": "Object subtype hint. Specified for `object` or `wasm` type values only.",
                             "optional": true,
                             "type": "string",
                             "enum": [
@@ -1919,7 +2158,13 @@
                                 "promise",
                                 "typedarray",
                                 "arraybuffer",
-                                "dataview"
+                                "dataview",
+                                "i32",
+                                "i64",
+                                "f32",
+                                "f64",
+                                "v128",
+                                "anyref"
                             ]
                         },
                         {
@@ -2230,6 +2475,19 @@
                         {
                             "name": "value",
                             "description": "The value associated with the private property.",
+                            "optional": true,
+                            "$ref": "RemoteObject"
+                        },
+                        {
+                            "name": "get",
+                            "description": "A function which serves as a getter for the private property,\nor `undefined` if there is no getter (accessor descriptors only).",
+                            "optional": true,
+                            "$ref": "RemoteObject"
+                        },
+                        {
+                            "name": "set",
+                            "description": "A function which serves as a setter for the private property,\nor `undefined` if there is no setter (accessor descriptors only).",
+                            "optional": true,
                             "$ref": "RemoteObject"
                         }
                     ]
@@ -2681,7 +2939,7 @@
                         },
                         {
                             "name": "throwOnSideEffect",
-                            "description": "Whether to throw an exception if side effect cannot be ruled out during evaluation.",
+                            "description": "Whether to throw an exception if side effect cannot be ruled out during evaluation.\nThis implies `disableBreaks` below.",
                             "experimental": true,
                             "optional": true,
                             "type": "boolean"
@@ -2692,6 +2950,20 @@
                             "experimental": true,
                             "optional": true,
                             "$ref": "TimeDelta"
+                        },
+                        {
+                            "name": "disableBreaks",
+                            "description": "Disable breakpoints during execution.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "replMode",
+                            "description": "Setting this flag to true enables `let` re-declaration and top-level `await`.\nNote that `let` variables can only be re-declared if they originate from\n`replMode` themselves.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ],
                     "returns": [


### PR DESCRIPTION
There's been a number of improvements to the upstream devtools protocol (e.g., https://chromium.googlesource.com/chromium/src/+/62277ea12ffb448cf4a4b3259fcda68b1a0757dc which adds downloadBehavior at browser level), which would be great to support as part of this library.

I've gone through the process and bumped the protocol to the latest version. Please let me know if any additional changes are necessary.

> Side note: @kklisura it'd be great if the copyright-addition could be automated as part of the make file, as that took me some time to setup/automate, since the generated files simply don't have any copyright notice by default.