### PR TITLE
Support Chrome 111+

### DIFF
--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/services/impl/ChromeServiceImpl.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/services/impl/ChromeServiceImpl.java
@@ -269,6 +269,7 @@ public class ChromeServiceImpl implements ChromeService {
     try {
       URL uri = new URL(String.format(path, params));
       connection = (HttpURLConnection) uri.openConnection();
+      connection.setRequestMethod("PUT");
 
       int responseCode = connection.getResponseCode();
       if (HttpURLConnection.HTTP_OK == responseCode) {

--- a/cdt-java-client/src/test/java/com/github/kklisura/cdt/services/impl/ChromeServiceImplTest.java
+++ b/cdt-java-client/src/test/java/com/github/kklisura/cdt/services/impl/ChromeServiceImplTest.java
@@ -98,7 +98,7 @@ public class ChromeServiceImplTest extends EasyMockSupport {
 
     RecordedRequest request = server.takeRequest();
     assertEquals(1, server.getRequestCount());
-    assertEquals("GET /json/list HTTP/1.1", request.getRequestLine());
+    assertEquals("PUT /json/list HTTP/1.1", request.getRequestLine());
 
     assertFalse(tabs.isEmpty());
     assertEquals(2, tabs.size());
@@ -138,7 +138,7 @@ public class ChromeServiceImplTest extends EasyMockSupport {
 
     RecordedRequest request = server.takeRequest();
     assertEquals(1, server.getRequestCount());
-    assertEquals("GET /json/new?some-tab-name HTTP/1.1", request.getRequestLine());
+    assertEquals("PUT /json/new?some-tab-name HTTP/1.1", request.getRequestLine());
 
     assertEquals("", tab.getDescription());
     assertEquals(
@@ -174,7 +174,7 @@ public class ChromeServiceImplTest extends EasyMockSupport {
 
     RecordedRequest request = server.takeRequest();
     assertEquals(1, server.getRequestCount());
-    assertEquals("GET /json/new?about:blank HTTP/1.1", request.getRequestLine());
+    assertEquals("PUT /json/new?about:blank HTTP/1.1", request.getRequestLine());
 
     assertEquals("", tab.getDescription());
     assertEquals(
@@ -212,7 +212,7 @@ public class ChromeServiceImplTest extends EasyMockSupport {
     RecordedRequest request = server.takeRequest();
     assertEquals(1, server.getRequestCount());
     assertEquals(
-        "GET /json/activate/D4CEC22C995F1A9C8526737014CD436D HTTP/1.1", request.getRequestLine());
+        "PUT /json/activate/D4CEC22C995F1A9C8526737014CD436D HTTP/1.1", request.getRequestLine());
 
     server.shutdown();
   }
@@ -267,7 +267,7 @@ public class ChromeServiceImplTest extends EasyMockSupport {
     RecordedRequest request = server.takeRequest();
     assertEquals(1, server.getRequestCount());
     assertEquals(
-        "GET /json/close/D4CEC22C995F1A9C8526737014CD436D HTTP/1.1", request.getRequestLine());
+        "PUT /json/close/D4CEC22C995F1A9C8526737014CD436D HTTP/1.1", request.getRequestLine());
 
     server.shutdown();
 
@@ -292,7 +292,7 @@ public class ChromeServiceImplTest extends EasyMockSupport {
     RecordedRequest request = server.takeRequest();
     assertEquals(1, server.getRequestCount());
     assertEquals(
-        "GET /json/close/D4CEC22C995F1A9C8526737014CD436D HTTP/1.1", request.getRequestLine());
+        "PUT /json/close/D4CEC22C995F1A9C8526737014CD436D HTTP/1.1", request.getRequestLine());
 
     server.shutdown();
   }
@@ -312,7 +312,7 @@ public class ChromeServiceImplTest extends EasyMockSupport {
 
     RecordedRequest request = server.takeRequest();
     assertEquals(1, server.getRequestCount());
-    assertEquals("GET /json/version HTTP/1.1", request.getRequestLine());
+    assertEquals("PUT /json/version HTTP/1.1", request.getRequestLine());
 
     assertEquals("Chrome/63.0.3239.132", version.getBrowser());
     assertEquals("1.2", version.getProtocolVersion());


### PR DESCRIPTION
Chrome 111 was just released which breaks this library.
HTTP `PUT` must now be used instead of `GET` for `json/new`. _Should_ work with older Chrome versions too.

Note that the origin for DevTools Websocket connections must now be specified explicitly, e.g. using `--remote-allow-origins=*` (see https://groups.google.com/g/chromedriver-users/c/xL5-13_qGaA).