### PR TITLE
Add Prefetch ResourceType

### DIFF
--- a/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/network/ResourceType.java
+++ b/cdt-java-client/src/main/java/com/github/kklisura/cdt/protocol/types/network/ResourceType.java
@@ -42,6 +42,8 @@ public enum ResourceType {
   XHR,
   @JsonProperty("Fetch")
   FETCH,
+  @JsonProperty("Prefetch")
+  PREFETCH,
   @JsonProperty("EventSource")
   EVENT_SOURCE,
   @JsonProperty("WebSocket")


### PR DESCRIPTION
Current protocol is missing the Prefetch resource type from the [latest version](https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-ResourceType)